### PR TITLE
Feature: add vhdl and verilog language support

### DIFF
--- a/catppuccin-macchiato.xml
+++ b/catppuccin-macchiato.xml
@@ -522,6 +522,41 @@
         <LexerType name="nfo" desc="Dos Style" ext="">
             <WordsStyle name="DEFAULT" styleID="32" fgColor="B8C0E0" bgColor="24273A" fontSize="" fontStyle="0" />
         </LexerType>
+        <LexerType name="verilog" desc="Verilog" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="E0E2E4" bgColor="24273A" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="E0E2E4" bgColor="24273A" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="TAGNAME" styleID="2" fgColor="E0E2E4" bgColor="24273A" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="A6DA95" bgColor="24273A" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="KEYWORD" styleID="7" fgColor="E0E2E4" bgColor="24273A" fontName="" fontStyle="0" fontSize="" keywordClass="type1"></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="EE99A0" bgColor="24273A" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="4" fgColor="F5A97F" bgColor="24273A" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="EED49F" bgColor="24273A" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING" styleID="6" fgColor="A6DA95" bgColor="24273A" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="8AADF4" bgColor="24273A" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="8AADF4" bgColor="24273A" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE BANG" styleID="3" fgColor="8AADF4" bgColor="24273A" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING EOL" styleID="12" fgColor="E0E2E4" bgColor="24273A" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="USER" styleID="19" fgColor="E0E2E4" bgColor="24273A" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="vhdl" desc="VHDL" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="E0E2E4" bgColor="24273A" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="8AADF4" bgColor="24273A" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="8AADF4" bgColor="24273A" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="3" fgColor="F5A97F" bgColor="24273A" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING" styleID="4" fgColor="A6DA95" bgColor="24273A" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="5" fgColor="EE99A0" bgColor="24273A" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="IDENTIFIER" styleID="6" fgColor="E0E2E4" bgColor="24273A" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING EOL" styleID="7" fgColor="E0E2E4" bgColor="24273A" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="INSTRUCTION" styleID="8" fgColor="A6DA95" bgColor="24273A" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="STD OPERATOR" styleID="9" fgColor="7DC4E4" bgColor="24273A" fontName="" fontStyle="0" fontSize="" keywordClass="instre2"></WordsStyle>
+            <WordsStyle name="ATTRIBUTE" styleID="10" fgColor="F4DBD6" bgColor="24273A" fontName="" fontStyle="0" fontSize="" keywordClass="type1"></WordsStyle>
+            <WordsStyle name="DIRECTIVE" styleID="9" fgColor="C6A0F6" bgColor="24273A" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="DIRECTIVE OPERAND" styleID="10" fgColor="C6A0F6" bgColor="24273A" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STD FUNCTION" styleID="11" fgColor="EED49F" bgColor="24273A" fontName="" fontStyle="0" fontSize="" keywordClass="type2"></WordsStyle>
+            <WordsStyle name="STD PACKAGE" styleID="12" fgColor="EED49F" bgColor="24273A" fontName="" fontStyle="0" fontSize="" keywordClass="type3"></WordsStyle>
+            <WordsStyle name="STD TYPE" styleID="13" fgColor="EED49F" bgColor="24273A" fontName="" fontStyle="0" fontSize="" keywordClass="type4"></WordsStyle>
+            <WordsStyle name="USER DEFINE" styleID="14" fgColor="E0E2E4" bgColor="24273A" fontName="" fontStyle="0" fontSize="" keywordClass="type5"></WordsStyle>
+        </LexerType>
     </LexerStyles>
     <GlobalStyles>
         <!-- Attention : Don't modify the name of styleID="0" -->


### PR DESCRIPTION
I have a color theme for Macchiato which I personally use. I am not sure what the best way to implement the other flavors. Is there any automated scripts or tools for 1:1 mapping? I am especially not familiar with Frappe, so I am unsure if the colors would map and look nice. Leaving this as a WIP until I can convert the other flavors.
Here is a preview of the macchiato for VHDL

![image](https://github.com/user-attachments/assets/5f07d1e4-bd0b-4059-b43b-14683280e54c)
