### PR TITLE
docs(usage): avoid suggesting git cloning repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,9 @@
 
 ## Usage
 
-1. Clone this repository locally
-2. Open `%AppData%\Notepad++\themes`
-3. Drag the `.xml` files into the folder
-4. In Notepad++: Settings > Style Configurator > Select theme > `catppuccin-...`
+1. Download your preferred flavor(s) from [`themes/`](./themes/).
+2. Move downloaded flavor(s) to `%AppData%\Notepad++\themes`.
+4. In Notepad++, go to **Settings** > **Style Configurator** > **Select theme**, and select your Catppuccin flavor.
 
 <details>
 <summary>🌻 Latte</summary>


### PR DESCRIPTION
Downloading the files from GitHub can be quicker and more convenient than cloning this whole repository, so we should suggest that instead.