### PR TITLE
feat: include change history gutter marks

### DIFF
--- a/notepad-plus-plus.tera
+++ b/notepad-plus-plus.tera
@@ -552,5 +552,9 @@ whiskers:
         <WidgetStyle name="Tags match highlighting" styleID="27" bgColor="{{ mauve.hex }}" fgColor="FFCAB0" fontStyle="0" />
         <WidgetStyle name="Smart HighLighting" styleID="29" bgColor="{{ sky.hex }}" fgColor="{{ text.hex }}" fontSize="" fontStyle="1" />
         <WidgetStyle name="Active tab focused indicator" styleID="0" fgColor="{{ red.hex }}" fontStyle="0" />
+        <WidgetStyle name="Change History modified" styleID="0" fgColor="{{ peach.hex }}" bgColor="{{ peach.hex }}" />
+        <WidgetStyle name="Change History revert modified" styleID="0" fgColor="{{ lavender.hex }}" bgColor="{{ lavender.hex }}" />
+        <WidgetStyle name="Change History revert origin" styleID="0" fgColor="{{ teal.hex }}" bgColor="{{ teal.hex }}" />
+        <WidgetStyle name="Change History saved" styleID="0" fgColor="{{ green.hex }}" bgColor="{{ green.hex }}" />
     </GlobalStyles>
 </NotepadPlus>

--- a/themes/catppuccin-frappe.xml
+++ b/themes/catppuccin-frappe.xml
@@ -544,5 +544,9 @@
         <WidgetStyle name="Tags match highlighting" styleID="27" bgColor="CA9EE6" fgColor="FFCAB0" fontStyle="0" />
         <WidgetStyle name="Smart HighLighting" styleID="29" bgColor="99D1DB" fgColor="C6D0F5" fontSize="" fontStyle="1" />
         <WidgetStyle name="Active tab focused indicator" styleID="0" fgColor="E78284" fontStyle="0" />
+        <WidgetStyle name="Change History modified" styleID="0" fgColor="EF9F76" bgColor="EF9F76" />
+        <WidgetStyle name="Change History revert modified" styleID="0" fgColor="BABBF1" bgColor="BABBF1" />
+        <WidgetStyle name="Change History revert origin" styleID="0" fgColor="81C8BE" bgColor="81C8BE" />
+        <WidgetStyle name="Change History saved" styleID="0" fgColor="A6D189" bgColor="A6D189" />
     </GlobalStyles>
 </NotepadPlus>

--- a/themes/catppuccin-latte.xml
+++ b/themes/catppuccin-latte.xml
@@ -544,5 +544,9 @@
         <WidgetStyle name="Tags match highlighting" styleID="27" bgColor="8839EF" fgColor="FFCAB0" fontStyle="0" />
         <WidgetStyle name="Smart HighLighting" styleID="29" bgColor="04A5E5" fgColor="4C4F69" fontSize="" fontStyle="1" />
         <WidgetStyle name="Active tab focused indicator" styleID="0" fgColor="D20F39" fontStyle="0" />
+        <WidgetStyle name="Change History modified" styleID="0" fgColor="FE640B" bgColor="FE640B" />
+        <WidgetStyle name="Change History revert modified" styleID="0" fgColor="7287FD" bgColor="7287FD" />
+        <WidgetStyle name="Change History revert origin" styleID="0" fgColor="179299" bgColor="179299" />
+        <WidgetStyle name="Change History saved" styleID="0" fgColor="40A02B" bgColor="40A02B" />
     </GlobalStyles>
 </NotepadPlus>

--- a/themes/catppuccin-macchiato.xml
+++ b/themes/catppuccin-macchiato.xml
@@ -544,5 +544,9 @@
         <WidgetStyle name="Tags match highlighting" styleID="27" bgColor="C6A0F6" fgColor="FFCAB0" fontStyle="0" />
         <WidgetStyle name="Smart HighLighting" styleID="29" bgColor="91D7E3" fgColor="CAD3F5" fontSize="" fontStyle="1" />
         <WidgetStyle name="Active tab focused indicator" styleID="0" fgColor="ED8796" fontStyle="0" />
+        <WidgetStyle name="Change History modified" styleID="0" fgColor="F5A97F" bgColor="F5A97F" />
+        <WidgetStyle name="Change History revert modified" styleID="0" fgColor="B7BDF8" bgColor="B7BDF8" />
+        <WidgetStyle name="Change History revert origin" styleID="0" fgColor="8BD5CA" bgColor="8BD5CA" />
+        <WidgetStyle name="Change History saved" styleID="0" fgColor="A6DA95" bgColor="A6DA95" />
     </GlobalStyles>
 </NotepadPlus>

--- a/themes/catppuccin-mocha.xml
+++ b/themes/catppuccin-mocha.xml
@@ -544,5 +544,9 @@
         <WidgetStyle name="Tags match highlighting" styleID="27" bgColor="CBA6F7" fgColor="FFCAB0" fontStyle="0" />
         <WidgetStyle name="Smart HighLighting" styleID="29" bgColor="89DCEB" fgColor="CDD6F4" fontSize="" fontStyle="1" />
         <WidgetStyle name="Active tab focused indicator" styleID="0" fgColor="F38BA8" fontStyle="0" />
+        <WidgetStyle name="Change History modified" styleID="0" fgColor="FAB387" bgColor="FAB387" />
+        <WidgetStyle name="Change History revert modified" styleID="0" fgColor="B4BEFE" bgColor="B4BEFE" />
+        <WidgetStyle name="Change History revert origin" styleID="0" fgColor="94E2D5" bgColor="94E2D5" />
+        <WidgetStyle name="Change History saved" styleID="0" fgColor="A6E3A1" bgColor="A6E3A1" />
     </GlobalStyles>
 </NotepadPlus>


### PR DESCRIPTION
notepad++ v8.4.6 and onward allows for changing the gutter highlight colors.
I have added the color styles for these markers. 
Willing to incorporate any feedback on the color choices. I chose colors I though looked nice and were close the the default. 

https://npp-user-manual.org/docs/editing/#change-history

![Screenshot 2025-02-13 113951](https://github.com/user-attachments/assets/746b20e6-cb60-4665-a7b5-b8f598872024)
![Screenshot 2025-02-13 113859](https://github.com/user-attachments/assets/c1743657-0867-441f-8481-8dcf79dd50fc)
