### PR TITLE
feat: theme eol and non-print character style

### DIFF
--- a/notepad-plus-plus.tera
+++ b/notepad-plus-plus.tera
@@ -591,5 +591,7 @@ whiskers:
         <WidgetStyle name="Change History revert modified" styleID="0" fgColor="{{ lavender.hex }}" bgColor="{{ lavender.hex }}" />
         <WidgetStyle name="Change History revert origin" styleID="0" fgColor="{{ teal.hex }}" bgColor="{{ teal.hex }}" />
         <WidgetStyle name="Change History saved" styleID="0" fgColor="{{ green.hex }}" bgColor="{{ green.hex }}" />
+        <WidgetStyle name="EOL custom color" styleID="0" fgColor="{{ subtext0.hex }}" />
+        <WidgetStyle name="Non-printing characters custom color" styleID="0" fgColor="{{ overlay0.hex }}" />
     </GlobalStyles>
 </NotepadPlus>

--- a/themes/catppuccin-frappe.xml
+++ b/themes/catppuccin-frappe.xml
@@ -583,5 +583,7 @@
         <WidgetStyle name="Change History revert modified" styleID="0" fgColor="BABBF1" bgColor="BABBF1" />
         <WidgetStyle name="Change History revert origin" styleID="0" fgColor="81C8BE" bgColor="81C8BE" />
         <WidgetStyle name="Change History saved" styleID="0" fgColor="A6D189" bgColor="A6D189" />
+        <WidgetStyle name="EOL custom color" styleID="0" fgColor="A5ADCE" />
+        <WidgetStyle name="Non-printing characters custom color" styleID="0" fgColor="737994" />
     </GlobalStyles>
 </NotepadPlus>

--- a/themes/catppuccin-latte.xml
+++ b/themes/catppuccin-latte.xml
@@ -583,5 +583,7 @@
         <WidgetStyle name="Change History revert modified" styleID="0" fgColor="7287FD" bgColor="7287FD" />
         <WidgetStyle name="Change History revert origin" styleID="0" fgColor="179299" bgColor="179299" />
         <WidgetStyle name="Change History saved" styleID="0" fgColor="40A02B" bgColor="40A02B" />
+        <WidgetStyle name="EOL custom color" styleID="0" fgColor="6C6F85" />
+        <WidgetStyle name="Non-printing characters custom color" styleID="0" fgColor="9CA0B0" />
     </GlobalStyles>
 </NotepadPlus>

--- a/themes/catppuccin-macchiato.xml
+++ b/themes/catppuccin-macchiato.xml
@@ -583,5 +583,7 @@
         <WidgetStyle name="Change History revert modified" styleID="0" fgColor="B7BDF8" bgColor="B7BDF8" />
         <WidgetStyle name="Change History revert origin" styleID="0" fgColor="8BD5CA" bgColor="8BD5CA" />
         <WidgetStyle name="Change History saved" styleID="0" fgColor="A6DA95" bgColor="A6DA95" />
+        <WidgetStyle name="EOL custom color" styleID="0" fgColor="A5ADCB" />
+        <WidgetStyle name="Non-printing characters custom color" styleID="0" fgColor="6E738D" />
     </GlobalStyles>
 </NotepadPlus>

--- a/themes/catppuccin-mocha.xml
+++ b/themes/catppuccin-mocha.xml
@@ -583,5 +583,7 @@
         <WidgetStyle name="Change History revert modified" styleID="0" fgColor="B4BEFE" bgColor="B4BEFE" />
         <WidgetStyle name="Change History revert origin" styleID="0" fgColor="94E2D5" bgColor="94E2D5" />
         <WidgetStyle name="Change History saved" styleID="0" fgColor="A6E3A1" bgColor="A6E3A1" />
+        <WidgetStyle name="EOL custom color" styleID="0" fgColor="A6ADC8" />
+        <WidgetStyle name="Non-printing characters custom color" styleID="0" fgColor="6C7086" />
     </GlobalStyles>
 </NotepadPlus>


### PR DESCRIPTION
In Notepad++ v8.5 onward, special hidden characters can have a custom theme color.

If users have the options enabled as described in: https://npp-user-manual.org/docs/views/#show-symbol, the characters will be themed appropriately.

Using yellow because I think it looks nice.

![image](https://github.com/user-attachments/assets/38019174-a493-430c-b3b0-442b7c7044a5)
