### PR TITLE
fix: xml prolog encoding to utf-8 for consistency

### DIFF
--- a/notepad-plus-plus.tera
+++ b/notepad-plus-plus.tera
@@ -6,7 +6,7 @@ whiskers:
   filename: "themes/catppuccin-{{ flavor.identifier }}.xml"
   hex_format: "{{R}}{{G}}{{B}}{{Z}}"
 ---
-<?xml version="1.0" encoding="Windows-1252" ?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <NotepadPlus>
     <LexerStyles>
         <LexerType name="java" desc="Java" ext="">

--- a/themes/catppuccin-frappe.xml
+++ b/themes/catppuccin-frappe.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="Windows-1252" ?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <NotepadPlus>
     <LexerStyles>
         <LexerType name="java" desc="Java" ext="">

--- a/themes/catppuccin-latte.xml
+++ b/themes/catppuccin-latte.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="Windows-1252" ?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <NotepadPlus>
     <LexerStyles>
         <LexerType name="java" desc="Java" ext="">

--- a/themes/catppuccin-macchiato.xml
+++ b/themes/catppuccin-macchiato.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="Windows-1252" ?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <NotepadPlus>
     <LexerStyles>
         <LexerType name="java" desc="Java" ext="">

--- a/themes/catppuccin-mocha.xml
+++ b/themes/catppuccin-mocha.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="Windows-1252" ?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <NotepadPlus>
     <LexerStyles>
         <LexerType name="java" desc="Java" ext="">


### PR DESCRIPTION
These files are already encoding in utf-8, this just fixes the xml prolog to be consistent, as stated in the docs:
https://npp-user-manual.org/docs/config-files/#configuration-file-encoding