### PR TITLE
feat: style marks and find-marks

### DIFF
--- a/notepad-plus-plus.tera
+++ b/notepad-plus-plus.tera
@@ -551,6 +551,12 @@ whiskers:
         <WidgetStyle name="Tags attribute" styleID="26" bgColor="{{ base.hex }}" fgColor="{{ text.hex }}" fontStyle="0" />
         <WidgetStyle name="Tags match highlighting" styleID="27" bgColor="{{ mauve.hex }}" fgColor="FFCAB0" fontStyle="0" />
         <WidgetStyle name="Smart HighLighting" styleID="29" bgColor="{{ sky.hex }}" fgColor="{{ text.hex }}" fontSize="" fontStyle="1" />
+        <WidgetStyle name="Find Mark Style" styleID="31" bgColor="{{ red.hex }}"></WidgetStyle>
+        <WidgetStyle name="Mark Style 1" styleID="25" bgColor="{{ sapphire.hex }}"></WidgetStyle>
+        <WidgetStyle name="Mark Style 2" styleID="24" bgColor="{{ peach.hex }}"></WidgetStyle>
+        <WidgetStyle name="Mark Style 3" styleID="23" bgColor="{{ yellow.hex }}"></WidgetStyle>
+        <WidgetStyle name="Mark Style 4" styleID="22" bgColor="{{ mauve.hex }}"></WidgetStyle>
+        <WidgetStyle name="Mark Style 5" styleID="21" bgColor="{{ green.hex }}"></WidgetStyle>
         <WidgetStyle name="Active tab focused indicator" styleID="0" fgColor="{{ red.hex }}" fontStyle="0" />
     </GlobalStyles>
 </NotepadPlus>

--- a/themes/catppuccin-frappe.xml
+++ b/themes/catppuccin-frappe.xml
@@ -543,6 +543,12 @@
         <WidgetStyle name="Tags attribute" styleID="26" bgColor="303446" fgColor="C6D0F5" fontStyle="0" />
         <WidgetStyle name="Tags match highlighting" styleID="27" bgColor="CA9EE6" fgColor="FFCAB0" fontStyle="0" />
         <WidgetStyle name="Smart HighLighting" styleID="29" bgColor="99D1DB" fgColor="C6D0F5" fontSize="" fontStyle="1" />
+        <WidgetStyle name="Find Mark Style" styleID="31" bgColor="E78284"></WidgetStyle>
+        <WidgetStyle name="Mark Style 1" styleID="25" bgColor="85C1DC"></WidgetStyle>
+        <WidgetStyle name="Mark Style 2" styleID="24" bgColor="EF9F76"></WidgetStyle>
+        <WidgetStyle name="Mark Style 3" styleID="23" bgColor="E5C890"></WidgetStyle>
+        <WidgetStyle name="Mark Style 4" styleID="22" bgColor="CA9EE6"></WidgetStyle>
+        <WidgetStyle name="Mark Style 5" styleID="21" bgColor="A6D189"></WidgetStyle>
         <WidgetStyle name="Active tab focused indicator" styleID="0" fgColor="E78284" fontStyle="0" />
     </GlobalStyles>
 </NotepadPlus>

--- a/themes/catppuccin-latte.xml
+++ b/themes/catppuccin-latte.xml
@@ -543,6 +543,12 @@
         <WidgetStyle name="Tags attribute" styleID="26" bgColor="EFF1F5" fgColor="4C4F69" fontStyle="0" />
         <WidgetStyle name="Tags match highlighting" styleID="27" bgColor="8839EF" fgColor="FFCAB0" fontStyle="0" />
         <WidgetStyle name="Smart HighLighting" styleID="29" bgColor="04A5E5" fgColor="4C4F69" fontSize="" fontStyle="1" />
+        <WidgetStyle name="Find Mark Style" styleID="31" bgColor="D20F39"></WidgetStyle>
+        <WidgetStyle name="Mark Style 1" styleID="25" bgColor="209FB5"></WidgetStyle>
+        <WidgetStyle name="Mark Style 2" styleID="24" bgColor="FE640B"></WidgetStyle>
+        <WidgetStyle name="Mark Style 3" styleID="23" bgColor="DF8E1D"></WidgetStyle>
+        <WidgetStyle name="Mark Style 4" styleID="22" bgColor="8839EF"></WidgetStyle>
+        <WidgetStyle name="Mark Style 5" styleID="21" bgColor="40A02B"></WidgetStyle>
         <WidgetStyle name="Active tab focused indicator" styleID="0" fgColor="D20F39" fontStyle="0" />
     </GlobalStyles>
 </NotepadPlus>

--- a/themes/catppuccin-macchiato.xml
+++ b/themes/catppuccin-macchiato.xml
@@ -543,6 +543,12 @@
         <WidgetStyle name="Tags attribute" styleID="26" bgColor="24273A" fgColor="CAD3F5" fontStyle="0" />
         <WidgetStyle name="Tags match highlighting" styleID="27" bgColor="C6A0F6" fgColor="FFCAB0" fontStyle="0" />
         <WidgetStyle name="Smart HighLighting" styleID="29" bgColor="91D7E3" fgColor="CAD3F5" fontSize="" fontStyle="1" />
+        <WidgetStyle name="Find Mark Style" styleID="31" bgColor="ED8796"></WidgetStyle>
+        <WidgetStyle name="Mark Style 1" styleID="25" bgColor="7DC4E4"></WidgetStyle>
+        <WidgetStyle name="Mark Style 2" styleID="24" bgColor="F5A97F"></WidgetStyle>
+        <WidgetStyle name="Mark Style 3" styleID="23" bgColor="EED49F"></WidgetStyle>
+        <WidgetStyle name="Mark Style 4" styleID="22" bgColor="C6A0F6"></WidgetStyle>
+        <WidgetStyle name="Mark Style 5" styleID="21" bgColor="A6DA95"></WidgetStyle>
         <WidgetStyle name="Active tab focused indicator" styleID="0" fgColor="ED8796" fontStyle="0" />
     </GlobalStyles>
 </NotepadPlus>

--- a/themes/catppuccin-mocha.xml
+++ b/themes/catppuccin-mocha.xml
@@ -543,6 +543,12 @@
         <WidgetStyle name="Tags attribute" styleID="26" bgColor="1E1E2E" fgColor="CDD6F4" fontStyle="0" />
         <WidgetStyle name="Tags match highlighting" styleID="27" bgColor="CBA6F7" fgColor="FFCAB0" fontStyle="0" />
         <WidgetStyle name="Smart HighLighting" styleID="29" bgColor="89DCEB" fgColor="CDD6F4" fontSize="" fontStyle="1" />
+        <WidgetStyle name="Find Mark Style" styleID="31" bgColor="F38BA8"></WidgetStyle>
+        <WidgetStyle name="Mark Style 1" styleID="25" bgColor="74C7EC"></WidgetStyle>
+        <WidgetStyle name="Mark Style 2" styleID="24" bgColor="FAB387"></WidgetStyle>
+        <WidgetStyle name="Mark Style 3" styleID="23" bgColor="F9E2AF"></WidgetStyle>
+        <WidgetStyle name="Mark Style 4" styleID="22" bgColor="CBA6F7"></WidgetStyle>
+        <WidgetStyle name="Mark Style 5" styleID="21" bgColor="A6E3A1"></WidgetStyle>
         <WidgetStyle name="Active tab focused indicator" styleID="0" fgColor="F38BA8" fontStyle="0" />
     </GlobalStyles>
 </NotepadPlus>


### PR DESCRIPTION
Notepad++ has a feature where you can selectively mark and highlight with 5 predefined mark colors.

https://npp-user-manual.org/docs/searching/#marking-with-a-colorstyle-and-highlighting

In the find menu, you can also mark all selections.

I have added these styles with catppuccin colors.
They have about 60% transparency added, so no sure if anything needs to be done about that, or if it works as is.

Before (Bad)
![Screenshot 2025-02-13 122928](https://github.com/user-attachments/assets/0c62428b-a4bf-456b-8053-9a43c7191551)

After:

![Screenshot 2025-02-13 123142](https://github.com/user-attachments/assets/b6c80bc5-2269-45a8-99a7-d2f11489150e)
![Screenshot 2025-02-13 123210](https://github.com/user-attachments/assets/5cfccb25-4806-4136-8047-507082d54ded)

