### PR TITLE
chore: mark themes/* as linguist-generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+themes/* linguist-generated=true


### PR DESCRIPTION
This will prevent showing diffs in Github PRs by default.
You can click the "show" button to view changes anyway.