### PR TITLE
fix: improve selected text and active line highlights

### DIFF
--- a/templates/editor.tera
+++ b/templates/editor.tera
@@ -6,6 +6,8 @@ whiskers:
   filename: "themes/catppuccin-{{ flavor.identifier }}.xml"
   hex_format: "{{R}}{{G}}{{B}}{{Z}}"
 ---
+{%- set line = text | mix(color=base, amount=0.1) -%}
+{%- set selected = overlay2 | mix(color=base, amount=0.30) -%}
 <?xml version="1.0" encoding="UTF-8" ?>
 <NotepadPlus>
     <LexerStyles>
@@ -572,28 +574,28 @@ whiskers:
         <WidgetStyle name="Global override" styleID="0" fgColor="{{ text.hex }}" bgColor="{{ base.hex }}" fontName="Consolas" fontStyle="0" fontSize="10" />
         <WidgetStyle name="Default Style" styleID="32" fgColor="{{ text.hex }}" bgColor="{{ base.hex }}" fontName="Consolas" fontStyle="0" fontSize="10" />
         <WidgetStyle name="Indent guideline style" styleID="37" fgColor="{{ blue.hex }}" bgColor="{{ base.hex }}" fontName="" fontStyle="0" fontSize="" />
-        <WidgetStyle name="Brace highlight style" styleID="34" fgColor="{{ text.hex }}" bgColor="{{ mauve.hex }}" fontName="" fontStyle="1" fontSize="10" />
+        <WidgetStyle name="Brace highlight style" styleID="34" fgColor="{{ text.hex }}" bgColor="{{ selected.hex }}" fontName="" fontStyle="1" fontSize="10" />
         <WidgetStyle name="Bad brace colour" styleID="35" fgColor="{{ text.hex }}" bgColor="{{ red.hex }}" fontName="" fontStyle="0" fontSize="" />
-        <WidgetStyle name="Current line background colour" styleID="0" bgColor="2F3142" fgColor="{{ text.hex }}" fontSize="" fontStyle="0" />
-        <WidgetStyle name="Selected text colour" styleID="0" bgColor="44475A" fgColor="{{ text.hex }}" fontStyle="0" />
-        <WidgetStyle name="Caret colour" styleID="2069" fgColor="{{ text.hex }}" bgColor="{{ base.hex }}" fontStyle="0" />
+        <WidgetStyle name="Current line background colour" styleID="0" bgColor="{{ line.hex }}" fgColor="{{ text.hex }}" fontSize="" fontStyle="0" />
+        <WidgetStyle name="Selected text colour" styleID="0" bgColor="{{ selected.hex }}" fontStyle="0" />
+        <WidgetStyle name="Caret colour" styleID="2069" fgColor="{{ rosewater.hex }}" bgColor="{{ base.hex }}" fontStyle="0" />
         <WidgetStyle name="Edge colour" styleID="0" fgColor="{{ text.hex }}" bgColor="{{ base.hex }}" fontSize="" fontStyle="0" />
-        <WidgetStyle name="Line number margin" styleID="33" fgColor="{{ mauve.hex }}" bgColor="{{ base.hex }}" fontName="" fontStyle="0" fontSize="" />
+        <WidgetStyle name="Line number margin" styleID="33" fgColor="{{ overlay1.hex }}" bgColor="{{ base.hex }}" fontName="" fontStyle="0" fontSize="" />
         <WidgetStyle name="Fold" styleID="0" fgColor="{{ mauve.hex }}" bgColor="{{ base.hex }}" fontStyle="0" fontSize="" />
         <WidgetStyle name="Fold active" styleID="0" fgColor="{{ mauve.hex }}" fontStyle="0" fontSize="" bgColor="{{ base.hex }}" />
         <WidgetStyle name="Fold margin" styleID="0" fgColor="{{ base.hex }}" bgColor="{{ base.hex }}" fontStyle="0" fontSize="" />
         <WidgetStyle name="White space symbol" styleID="0" fgColor="{{ blue.hex }}" bgColor="{{ base.hex }}" fontStyle="0" fontSize="" />
-        <WidgetStyle name="URL hovered" styleID="0" fgColor="{{ green.hex }}" bgColor="{{ base.hex }}" fontStyle="0" />
+        <WidgetStyle name="URL hovered" styleID="0" fgColor="{{ sky.hex }}" bgColor="{{ base.hex }}" fontStyle="0" />
         <WidgetStyle name="Tags attribute" styleID="26" bgColor="{{ base.hex }}" fgColor="{{ text.hex }}" fontStyle="0" />
-        <WidgetStyle name="Tags match highlighting" styleID="27" bgColor="{{ mauve.hex }}" fgColor="FFCAB0" fontStyle="0" />
-        <WidgetStyle name="Smart HighLighting" styleID="29" bgColor="{{ sky.hex }}" fgColor="{{ text.hex }}" fontSize="" fontStyle="1" />
+        <WidgetStyle name="Tags match highlighting" styleID="27" bgColor="{{ selected.hex }}" fgColor="{{ text.hex }}" fontStyle="0" />
+        <WidgetStyle name="Smart HighLighting" styleID="29" bgColor="{{ overlay2.hex }}" fgColor="{{ text.hex }}" fontSize="" fontStyle="1" />
         <WidgetStyle name="Find Mark Style" styleID="31" bgColor="{{ red.hex }}"></WidgetStyle>
         <WidgetStyle name="Mark Style 1" styleID="25" bgColor="{{ sapphire.hex }}"></WidgetStyle>
         <WidgetStyle name="Mark Style 2" styleID="24" bgColor="{{ peach.hex }}"></WidgetStyle>
         <WidgetStyle name="Mark Style 3" styleID="23" bgColor="{{ yellow.hex }}"></WidgetStyle>
         <WidgetStyle name="Mark Style 4" styleID="22" bgColor="{{ mauve.hex }}"></WidgetStyle>
         <WidgetStyle name="Mark Style 5" styleID="21" bgColor="{{ green.hex }}"></WidgetStyle>
-        <WidgetStyle name="Active tab focused indicator" styleID="0" fgColor="{{ red.hex }}" fontStyle="0" />
+        <WidgetStyle name="Active tab focused indicator" styleID="0" fgColor="{{ lavender.hex }}" fontStyle="0" />
         <WidgetStyle name="Change History modified" styleID="0" fgColor="{{ peach.hex }}" bgColor="{{ peach.hex }}" />
         <WidgetStyle name="Change History revert modified" styleID="0" fgColor="{{ lavender.hex }}" bgColor="{{ lavender.hex }}" />
         <WidgetStyle name="Change History revert origin" styleID="0" fgColor="{{ teal.hex }}" bgColor="{{ teal.hex }}" />

--- a/themes/catppuccin-frappe.xml
+++ b/themes/catppuccin-frappe.xml
@@ -564,28 +564,28 @@
         <WidgetStyle name="Global override" styleID="0" fgColor="C6D0F5" bgColor="303446" fontName="Consolas" fontStyle="0" fontSize="10" />
         <WidgetStyle name="Default Style" styleID="32" fgColor="C6D0F5" bgColor="303446" fontName="Consolas" fontStyle="0" fontSize="10" />
         <WidgetStyle name="Indent guideline style" styleID="37" fgColor="8CAAEE" bgColor="303446" fontName="" fontStyle="0" fontSize="" />
-        <WidgetStyle name="Brace highlight style" styleID="34" fgColor="C6D0F5" bgColor="CA9EE6" fontName="" fontStyle="1" fontSize="10" />
+        <WidgetStyle name="Brace highlight style" styleID="34" fgColor="C6D0F5" bgColor="4F5369" fontName="" fontStyle="1" fontSize="10" />
         <WidgetStyle name="Bad brace colour" styleID="35" fgColor="C6D0F5" bgColor="E78284" fontName="" fontStyle="0" fontSize="" />
-        <WidgetStyle name="Current line background colour" styleID="0" bgColor="2F3142" fgColor="C6D0F5" fontSize="" fontStyle="0" />
-        <WidgetStyle name="Selected text colour" styleID="0" bgColor="44475A" fgColor="C6D0F5" fontStyle="0" />
-        <WidgetStyle name="Caret colour" styleID="2069" fgColor="C6D0F5" bgColor="303446" fontStyle="0" />
+        <WidgetStyle name="Current line background colour" styleID="0" bgColor="3F4458" fgColor="C6D0F5" fontSize="" fontStyle="0" />
+        <WidgetStyle name="Selected text colour" styleID="0" bgColor="4F5369" fontStyle="0" />
+        <WidgetStyle name="Caret colour" styleID="2069" fgColor="F2D5CF" bgColor="303446" fontStyle="0" />
         <WidgetStyle name="Edge colour" styleID="0" fgColor="C6D0F5" bgColor="303446" fontSize="" fontStyle="0" />
-        <WidgetStyle name="Line number margin" styleID="33" fgColor="CA9EE6" bgColor="303446" fontName="" fontStyle="0" fontSize="" />
+        <WidgetStyle name="Line number margin" styleID="33" fgColor="838BA7" bgColor="303446" fontName="" fontStyle="0" fontSize="" />
         <WidgetStyle name="Fold" styleID="0" fgColor="CA9EE6" bgColor="303446" fontStyle="0" fontSize="" />
         <WidgetStyle name="Fold active" styleID="0" fgColor="CA9EE6" fontStyle="0" fontSize="" bgColor="303446" />
         <WidgetStyle name="Fold margin" styleID="0" fgColor="303446" bgColor="303446" fontStyle="0" fontSize="" />
         <WidgetStyle name="White space symbol" styleID="0" fgColor="8CAAEE" bgColor="303446" fontStyle="0" fontSize="" />
-        <WidgetStyle name="URL hovered" styleID="0" fgColor="A6D189" bgColor="303446" fontStyle="0" />
+        <WidgetStyle name="URL hovered" styleID="0" fgColor="99D1DB" bgColor="303446" fontStyle="0" />
         <WidgetStyle name="Tags attribute" styleID="26" bgColor="303446" fgColor="C6D0F5" fontStyle="0" />
-        <WidgetStyle name="Tags match highlighting" styleID="27" bgColor="CA9EE6" fgColor="FFCAB0" fontStyle="0" />
-        <WidgetStyle name="Smart HighLighting" styleID="29" bgColor="99D1DB" fgColor="C6D0F5" fontSize="" fontStyle="1" />
+        <WidgetStyle name="Tags match highlighting" styleID="27" bgColor="4F5369" fgColor="C6D0F5" fontStyle="0" />
+        <WidgetStyle name="Smart HighLighting" styleID="29" bgColor="949CBB" fgColor="C6D0F5" fontSize="" fontStyle="1" />
         <WidgetStyle name="Find Mark Style" styleID="31" bgColor="E78284"></WidgetStyle>
         <WidgetStyle name="Mark Style 1" styleID="25" bgColor="85C1DC"></WidgetStyle>
         <WidgetStyle name="Mark Style 2" styleID="24" bgColor="EF9F76"></WidgetStyle>
         <WidgetStyle name="Mark Style 3" styleID="23" bgColor="E5C890"></WidgetStyle>
         <WidgetStyle name="Mark Style 4" styleID="22" bgColor="CA9EE6"></WidgetStyle>
         <WidgetStyle name="Mark Style 5" styleID="21" bgColor="A6D189"></WidgetStyle>
-        <WidgetStyle name="Active tab focused indicator" styleID="0" fgColor="E78284" fontStyle="0" />
+        <WidgetStyle name="Active tab focused indicator" styleID="0" fgColor="BABBF1" fontStyle="0" />
         <WidgetStyle name="Change History modified" styleID="0" fgColor="EF9F76" bgColor="EF9F76" />
         <WidgetStyle name="Change History revert modified" styleID="0" fgColor="BABBF1" bgColor="BABBF1" />
         <WidgetStyle name="Change History revert origin" styleID="0" fgColor="81C8BE" bgColor="81C8BE" />

--- a/themes/catppuccin-latte.xml
+++ b/themes/catppuccin-latte.xml
@@ -564,28 +564,28 @@
         <WidgetStyle name="Global override" styleID="0" fgColor="4C4F69" bgColor="EFF1F5" fontName="Consolas" fontStyle="0" fontSize="10" />
         <WidgetStyle name="Default Style" styleID="32" fgColor="4C4F69" bgColor="EFF1F5" fontName="Consolas" fontStyle="0" fontSize="10" />
         <WidgetStyle name="Indent guideline style" styleID="37" fgColor="1E66F5" bgColor="EFF1F5" fontName="" fontStyle="0" fontSize="" />
-        <WidgetStyle name="Brace highlight style" styleID="34" fgColor="4C4F69" bgColor="8839EF" fontName="" fontStyle="1" fontSize="10" />
+        <WidgetStyle name="Brace highlight style" styleID="34" fgColor="4C4F69" bgColor="CCCED7" fontName="" fontStyle="1" fontSize="10" />
         <WidgetStyle name="Bad brace colour" styleID="35" fgColor="4C4F69" bgColor="D20F39" fontName="" fontStyle="0" fontSize="" />
-        <WidgetStyle name="Current line background colour" styleID="0" bgColor="2F3142" fgColor="4C4F69" fontSize="" fontStyle="0" />
-        <WidgetStyle name="Selected text colour" styleID="0" bgColor="44475A" fgColor="4C4F69" fontStyle="0" />
-        <WidgetStyle name="Caret colour" styleID="2069" fgColor="4C4F69" bgColor="EFF1F5" fontStyle="0" />
+        <WidgetStyle name="Current line background colour" styleID="0" bgColor="DFE0E7" fgColor="4C4F69" fontSize="" fontStyle="0" />
+        <WidgetStyle name="Selected text colour" styleID="0" bgColor="CCCED7" fontStyle="0" />
+        <WidgetStyle name="Caret colour" styleID="2069" fgColor="DC8A78" bgColor="EFF1F5" fontStyle="0" />
         <WidgetStyle name="Edge colour" styleID="0" fgColor="4C4F69" bgColor="EFF1F5" fontSize="" fontStyle="0" />
-        <WidgetStyle name="Line number margin" styleID="33" fgColor="8839EF" bgColor="EFF1F5" fontName="" fontStyle="0" fontSize="" />
+        <WidgetStyle name="Line number margin" styleID="33" fgColor="8C8FA1" bgColor="EFF1F5" fontName="" fontStyle="0" fontSize="" />
         <WidgetStyle name="Fold" styleID="0" fgColor="8839EF" bgColor="EFF1F5" fontStyle="0" fontSize="" />
         <WidgetStyle name="Fold active" styleID="0" fgColor="8839EF" fontStyle="0" fontSize="" bgColor="EFF1F5" />
         <WidgetStyle name="Fold margin" styleID="0" fgColor="EFF1F5" bgColor="EFF1F5" fontStyle="0" fontSize="" />
         <WidgetStyle name="White space symbol" styleID="0" fgColor="1E66F5" bgColor="EFF1F5" fontStyle="0" fontSize="" />
-        <WidgetStyle name="URL hovered" styleID="0" fgColor="40A02B" bgColor="EFF1F5" fontStyle="0" />
+        <WidgetStyle name="URL hovered" styleID="0" fgColor="04A5E5" bgColor="EFF1F5" fontStyle="0" />
         <WidgetStyle name="Tags attribute" styleID="26" bgColor="EFF1F5" fgColor="4C4F69" fontStyle="0" />
-        <WidgetStyle name="Tags match highlighting" styleID="27" bgColor="8839EF" fgColor="FFCAB0" fontStyle="0" />
-        <WidgetStyle name="Smart HighLighting" styleID="29" bgColor="04A5E5" fgColor="4C4F69" fontSize="" fontStyle="1" />
+        <WidgetStyle name="Tags match highlighting" styleID="27" bgColor="CCCED7" fgColor="4C4F69" fontStyle="0" />
+        <WidgetStyle name="Smart HighLighting" styleID="29" bgColor="7C7F93" fgColor="4C4F69" fontSize="" fontStyle="1" />
         <WidgetStyle name="Find Mark Style" styleID="31" bgColor="D20F39"></WidgetStyle>
         <WidgetStyle name="Mark Style 1" styleID="25" bgColor="209FB5"></WidgetStyle>
         <WidgetStyle name="Mark Style 2" styleID="24" bgColor="FE640B"></WidgetStyle>
         <WidgetStyle name="Mark Style 3" styleID="23" bgColor="DF8E1D"></WidgetStyle>
         <WidgetStyle name="Mark Style 4" styleID="22" bgColor="8839EF"></WidgetStyle>
         <WidgetStyle name="Mark Style 5" styleID="21" bgColor="40A02B"></WidgetStyle>
-        <WidgetStyle name="Active tab focused indicator" styleID="0" fgColor="D20F39" fontStyle="0" />
+        <WidgetStyle name="Active tab focused indicator" styleID="0" fgColor="7287FD" fontStyle="0" />
         <WidgetStyle name="Change History modified" styleID="0" fgColor="FE640B" bgColor="FE640B" />
         <WidgetStyle name="Change History revert modified" styleID="0" fgColor="7287FD" bgColor="7287FD" />
         <WidgetStyle name="Change History revert origin" styleID="0" fgColor="179299" bgColor="179299" />

--- a/themes/catppuccin-macchiato.xml
+++ b/themes/catppuccin-macchiato.xml
@@ -564,28 +564,28 @@
         <WidgetStyle name="Global override" styleID="0" fgColor="CAD3F5" bgColor="24273A" fontName="Consolas" fontStyle="0" fontSize="10" />
         <WidgetStyle name="Default Style" styleID="32" fgColor="CAD3F5" bgColor="24273A" fontName="Consolas" fontStyle="0" fontSize="10" />
         <WidgetStyle name="Indent guideline style" styleID="37" fgColor="8AADF4" bgColor="24273A" fontName="" fontStyle="0" fontSize="" />
-        <WidgetStyle name="Brace highlight style" styleID="34" fgColor="CAD3F5" bgColor="C6A0F6" fontName="" fontStyle="1" fontSize="10" />
+        <WidgetStyle name="Brace highlight style" styleID="34" fgColor="CAD3F5" bgColor="454A5F" fontName="" fontStyle="1" fontSize="10" />
         <WidgetStyle name="Bad brace colour" styleID="35" fgColor="CAD3F5" bgColor="ED8796" fontName="" fontStyle="0" fontSize="" />
-        <WidgetStyle name="Current line background colour" styleID="0" bgColor="2F3142" fgColor="CAD3F5" fontSize="" fontStyle="0" />
-        <WidgetStyle name="Selected text colour" styleID="0" bgColor="44475A" fgColor="CAD3F5" fontStyle="0" />
-        <WidgetStyle name="Caret colour" styleID="2069" fgColor="CAD3F5" bgColor="24273A" fontStyle="0" />
+        <WidgetStyle name="Current line background colour" styleID="0" bgColor="35394D" fgColor="CAD3F5" fontSize="" fontStyle="0" />
+        <WidgetStyle name="Selected text colour" styleID="0" bgColor="454A5F" fontStyle="0" />
+        <WidgetStyle name="Caret colour" styleID="2069" fgColor="F4DBD6" bgColor="24273A" fontStyle="0" />
         <WidgetStyle name="Edge colour" styleID="0" fgColor="CAD3F5" bgColor="24273A" fontSize="" fontStyle="0" />
-        <WidgetStyle name="Line number margin" styleID="33" fgColor="C6A0F6" bgColor="24273A" fontName="" fontStyle="0" fontSize="" />
+        <WidgetStyle name="Line number margin" styleID="33" fgColor="8087A2" bgColor="24273A" fontName="" fontStyle="0" fontSize="" />
         <WidgetStyle name="Fold" styleID="0" fgColor="C6A0F6" bgColor="24273A" fontStyle="0" fontSize="" />
         <WidgetStyle name="Fold active" styleID="0" fgColor="C6A0F6" fontStyle="0" fontSize="" bgColor="24273A" />
         <WidgetStyle name="Fold margin" styleID="0" fgColor="24273A" bgColor="24273A" fontStyle="0" fontSize="" />
         <WidgetStyle name="White space symbol" styleID="0" fgColor="8AADF4" bgColor="24273A" fontStyle="0" fontSize="" />
-        <WidgetStyle name="URL hovered" styleID="0" fgColor="A6DA95" bgColor="24273A" fontStyle="0" />
+        <WidgetStyle name="URL hovered" styleID="0" fgColor="91D7E3" bgColor="24273A" fontStyle="0" />
         <WidgetStyle name="Tags attribute" styleID="26" bgColor="24273A" fgColor="CAD3F5" fontStyle="0" />
-        <WidgetStyle name="Tags match highlighting" styleID="27" bgColor="C6A0F6" fgColor="FFCAB0" fontStyle="0" />
-        <WidgetStyle name="Smart HighLighting" styleID="29" bgColor="91D7E3" fgColor="CAD3F5" fontSize="" fontStyle="1" />
+        <WidgetStyle name="Tags match highlighting" styleID="27" bgColor="454A5F" fgColor="CAD3F5" fontStyle="0" />
+        <WidgetStyle name="Smart HighLighting" styleID="29" bgColor="939AB7" fgColor="CAD3F5" fontSize="" fontStyle="1" />
         <WidgetStyle name="Find Mark Style" styleID="31" bgColor="ED8796"></WidgetStyle>
         <WidgetStyle name="Mark Style 1" styleID="25" bgColor="7DC4E4"></WidgetStyle>
         <WidgetStyle name="Mark Style 2" styleID="24" bgColor="F5A97F"></WidgetStyle>
         <WidgetStyle name="Mark Style 3" styleID="23" bgColor="EED49F"></WidgetStyle>
         <WidgetStyle name="Mark Style 4" styleID="22" bgColor="C6A0F6"></WidgetStyle>
         <WidgetStyle name="Mark Style 5" styleID="21" bgColor="A6DA95"></WidgetStyle>
-        <WidgetStyle name="Active tab focused indicator" styleID="0" fgColor="ED8796" fontStyle="0" />
+        <WidgetStyle name="Active tab focused indicator" styleID="0" fgColor="B7BDF8" fontStyle="0" />
         <WidgetStyle name="Change History modified" styleID="0" fgColor="F5A97F" bgColor="F5A97F" />
         <WidgetStyle name="Change History revert modified" styleID="0" fgColor="B7BDF8" bgColor="B7BDF8" />
         <WidgetStyle name="Change History revert origin" styleID="0" fgColor="8BD5CA" bgColor="8BD5CA" />

--- a/themes/catppuccin-mocha.xml
+++ b/themes/catppuccin-mocha.xml
@@ -564,28 +564,28 @@
         <WidgetStyle name="Global override" styleID="0" fgColor="CDD6F4" bgColor="1E1E2E" fontName="Consolas" fontStyle="0" fontSize="10" />
         <WidgetStyle name="Default Style" styleID="32" fgColor="CDD6F4" bgColor="1E1E2E" fontName="Consolas" fontStyle="0" fontSize="10" />
         <WidgetStyle name="Indent guideline style" styleID="37" fgColor="89B4FA" bgColor="1E1E2E" fontName="" fontStyle="0" fontSize="" />
-        <WidgetStyle name="Brace highlight style" styleID="34" fgColor="CDD6F4" bgColor="CBA6F7" fontName="" fontStyle="1" fontSize="10" />
+        <WidgetStyle name="Brace highlight style" styleID="34" fgColor="CDD6F4" bgColor="414356" fontName="" fontStyle="1" fontSize="10" />
         <WidgetStyle name="Bad brace colour" styleID="35" fgColor="CDD6F4" bgColor="F38BA8" fontName="" fontStyle="0" fontSize="" />
-        <WidgetStyle name="Current line background colour" styleID="0" bgColor="2F3142" fgColor="CDD6F4" fontSize="" fontStyle="0" />
-        <WidgetStyle name="Selected text colour" styleID="0" bgColor="44475A" fgColor="CDD6F4" fontStyle="0" />
-        <WidgetStyle name="Caret colour" styleID="2069" fgColor="CDD6F4" bgColor="1E1E2E" fontStyle="0" />
+        <WidgetStyle name="Current line background colour" styleID="0" bgColor="303142" fgColor="CDD6F4" fontSize="" fontStyle="0" />
+        <WidgetStyle name="Selected text colour" styleID="0" bgColor="414356" fontStyle="0" />
+        <WidgetStyle name="Caret colour" styleID="2069" fgColor="F5E0DC" bgColor="1E1E2E" fontStyle="0" />
         <WidgetStyle name="Edge colour" styleID="0" fgColor="CDD6F4" bgColor="1E1E2E" fontSize="" fontStyle="0" />
-        <WidgetStyle name="Line number margin" styleID="33" fgColor="CBA6F7" bgColor="1E1E2E" fontName="" fontStyle="0" fontSize="" />
+        <WidgetStyle name="Line number margin" styleID="33" fgColor="7F849C" bgColor="1E1E2E" fontName="" fontStyle="0" fontSize="" />
         <WidgetStyle name="Fold" styleID="0" fgColor="CBA6F7" bgColor="1E1E2E" fontStyle="0" fontSize="" />
         <WidgetStyle name="Fold active" styleID="0" fgColor="CBA6F7" fontStyle="0" fontSize="" bgColor="1E1E2E" />
         <WidgetStyle name="Fold margin" styleID="0" fgColor="1E1E2E" bgColor="1E1E2E" fontStyle="0" fontSize="" />
         <WidgetStyle name="White space symbol" styleID="0" fgColor="89B4FA" bgColor="1E1E2E" fontStyle="0" fontSize="" />
-        <WidgetStyle name="URL hovered" styleID="0" fgColor="A6E3A1" bgColor="1E1E2E" fontStyle="0" />
+        <WidgetStyle name="URL hovered" styleID="0" fgColor="89DCEB" bgColor="1E1E2E" fontStyle="0" />
         <WidgetStyle name="Tags attribute" styleID="26" bgColor="1E1E2E" fgColor="CDD6F4" fontStyle="0" />
-        <WidgetStyle name="Tags match highlighting" styleID="27" bgColor="CBA6F7" fgColor="FFCAB0" fontStyle="0" />
-        <WidgetStyle name="Smart HighLighting" styleID="29" bgColor="89DCEB" fgColor="CDD6F4" fontSize="" fontStyle="1" />
+        <WidgetStyle name="Tags match highlighting" styleID="27" bgColor="414356" fgColor="CDD6F4" fontStyle="0" />
+        <WidgetStyle name="Smart HighLighting" styleID="29" bgColor="9399B2" fgColor="CDD6F4" fontSize="" fontStyle="1" />
         <WidgetStyle name="Find Mark Style" styleID="31" bgColor="F38BA8"></WidgetStyle>
         <WidgetStyle name="Mark Style 1" styleID="25" bgColor="74C7EC"></WidgetStyle>
         <WidgetStyle name="Mark Style 2" styleID="24" bgColor="FAB387"></WidgetStyle>
         <WidgetStyle name="Mark Style 3" styleID="23" bgColor="F9E2AF"></WidgetStyle>
         <WidgetStyle name="Mark Style 4" styleID="22" bgColor="CBA6F7"></WidgetStyle>
         <WidgetStyle name="Mark Style 5" styleID="21" bgColor="A6E3A1"></WidgetStyle>
-        <WidgetStyle name="Active tab focused indicator" styleID="0" fgColor="F38BA8" fontStyle="0" />
+        <WidgetStyle name="Active tab focused indicator" styleID="0" fgColor="B4BEFE" fontStyle="0" />
         <WidgetStyle name="Change History modified" styleID="0" fgColor="FAB387" bgColor="FAB387" />
         <WidgetStyle name="Change History revert modified" styleID="0" fgColor="B4BEFE" bgColor="B4BEFE" />
         <WidgetStyle name="Change History revert origin" styleID="0" fgColor="94E2D5" bgColor="94E2D5" />


### PR DESCRIPTION
There were hard-coded selected text and active line overlay colors that I fixed. This makes selected text and active line consistent across flavors.
I also changed the automatic brace and "smart text" match highlighting to use a common 'selected text' mix (overlay2 30% mix with base).

If there is a better way to do this in whiskers + tera let me know.

Before:
![Screenshot 2025-02-14 130223](https://github.com/user-attachments/assets/3cab1fd8-ecd0-49e6-b813-8507f2f58ae8)
![Screenshot 2025-02-14 130245](https://github.com/user-attachments/assets/9edc2962-7691-49f3-9f42-a1e575acbd49)
Fixed:
![Screenshot 2025-02-14 124719](https://github.com/user-attachments/assets/a3c4dbd7-4ba7-40ae-b826-f37a7e0953bc)
![Screenshot 2025-02-14 124651](https://github.com/user-attachments/assets/fb3f3665-34e4-4850-b39c-f705c7e05a2a)
