### PR TITLE
feat: add missing and new global style groups

### DIFF
--- a/templates/editor.tera
+++ b/templates/editor.tera
@@ -578,16 +578,17 @@ whiskers:
         <WidgetStyle name="Bad brace colour" styleID="35" fgColor="{{ text.hex }}" bgColor="{{ red.hex }}" fontName="" fontStyle="0" fontSize="" />
         <WidgetStyle name="Current line background colour" styleID="0" bgColor="{{ line.hex }}" fgColor="{{ text.hex }}" fontSize="" fontStyle="0" />
         <WidgetStyle name="Selected text colour" styleID="0" bgColor="{{ selected.hex }}" fontStyle="0" />
+        <WidgetStyle name="Multi-selected text color" styleID="0" bgColor="{{ selected.hex }}" />
         <WidgetStyle name="Caret colour" styleID="2069" fgColor="{{ rosewater.hex }}" bgColor="{{ base.hex }}" fontStyle="0" />
+        <WidgetStyle name="Multi-edit carets color" styleID="0" fgColor="{{ rosewater.hex }}" />
         <WidgetStyle name="Edge colour" styleID="0" fgColor="{{ text.hex }}" bgColor="{{ base.hex }}" fontSize="" fontStyle="0" />
         <WidgetStyle name="Line number margin" styleID="33" fgColor="{{ overlay1.hex }}" bgColor="{{ base.hex }}" fontName="" fontStyle="0" fontSize="" />
+        <WidgetStyle name="Bookmark margin" styleID="0" bgColor="{{ base.hex }}" />
+        <WidgetStyle name="Change History margin" styleID="0" bgColor="{{ base.hex }}" />
         <WidgetStyle name="Fold" styleID="0" fgColor="{{ mauve.hex }}" bgColor="{{ base.hex }}" fontStyle="0" fontSize="" />
         <WidgetStyle name="Fold active" styleID="0" fgColor="{{ mauve.hex }}" fontStyle="0" fontSize="" bgColor="{{ base.hex }}" />
         <WidgetStyle name="Fold margin" styleID="0" fgColor="{{ base.hex }}" bgColor="{{ base.hex }}" fontStyle="0" fontSize="" />
         <WidgetStyle name="White space symbol" styleID="0" fgColor="{{ blue.hex }}" bgColor="{{ base.hex }}" fontStyle="0" fontSize="" />
-        <WidgetStyle name="URL hovered" styleID="0" fgColor="{{ sky.hex }}" bgColor="{{ base.hex }}" fontStyle="0" />
-        <WidgetStyle name="Tags attribute" styleID="26" bgColor="{{ base.hex }}" fgColor="{{ text.hex }}" fontStyle="0" />
-        <WidgetStyle name="Tags match highlighting" styleID="27" bgColor="{{ selected.hex }}" fgColor="{{ text.hex }}" fontStyle="0" />
         <WidgetStyle name="Smart HighLighting" styleID="29" bgColor="{{ overlay2.hex }}" fgColor="{{ text.hex }}" fontSize="" fontStyle="1" />
         <WidgetStyle name="Find Mark Style" styleID="31" bgColor="{{ red.hex }}"></WidgetStyle>
         <WidgetStyle name="Mark Style 1" styleID="25" bgColor="{{ sapphire.hex }}"></WidgetStyle>
@@ -595,12 +596,20 @@ whiskers:
         <WidgetStyle name="Mark Style 3" styleID="23" bgColor="{{ yellow.hex }}"></WidgetStyle>
         <WidgetStyle name="Mark Style 4" styleID="22" bgColor="{{ mauve.hex }}"></WidgetStyle>
         <WidgetStyle name="Mark Style 5" styleID="21" bgColor="{{ green.hex }}"></WidgetStyle>
-        <WidgetStyle name="Active tab focused indicator" styleID="0" fgColor="{{ lavender.hex }}" fontStyle="0" />
+        <WidgetStyle name="Incremental highlight all" styleID="28" bgColor="{{ blue.hex }}" />
+        <WidgetStyle name="Tags match highlighting" styleID="27" bgColor="{{ selected.hex }}" fgColor="{{ text.hex }}" fontStyle="0" />
+        <WidgetStyle name="Tags attribute" styleID="26" bgColor="{{ base.hex }}" fgColor="{{ text.hex }}" fontStyle="0" />
+        <WidgetStyle name="Active tab focused indicator" styleID="0" fgColor="{{ lavender.hex }}" />
+        <WidgetStyle name="Active tab unfocused indicator" styleID="0" fgColor="{{ sapphire.hex }}" />
+        <WidgetStyle name="Active tab text" styleID="0" fgColor="{{ lavender.hex }}" />
+        <WidgetStyle name="Inactive tabs" styleID="0" fgColor="{{ subtext1.hex }}" bgColor="{{ crust.hex }}" />
+        <WidgetStyle name="URL hovered" styleID="0" fgColor="{{ sky.hex }}" bgColor="{{ base.hex }}" fontStyle="0" />
+        <WidgetStyle name="Document map" styleID="0" fgColor="{{ sky.hex }}" bgColor="{{ surface2.hex }}" />
+        <WidgetStyle name="EOL custom color" styleID="0" fgColor="{{ subtext0.hex }}" />
+        <WidgetStyle name="Non-printing characters custom color" styleID="0" fgColor="{{ overlay0.hex }}" />
         <WidgetStyle name="Change History modified" styleID="0" fgColor="{{ peach.hex }}" bgColor="{{ peach.hex }}" />
         <WidgetStyle name="Change History revert modified" styleID="0" fgColor="{{ lavender.hex }}" bgColor="{{ lavender.hex }}" />
         <WidgetStyle name="Change History revert origin" styleID="0" fgColor="{{ teal.hex }}" bgColor="{{ teal.hex }}" />
         <WidgetStyle name="Change History saved" styleID="0" fgColor="{{ green.hex }}" bgColor="{{ green.hex }}" />
-        <WidgetStyle name="EOL custom color" styleID="0" fgColor="{{ subtext0.hex }}" />
-        <WidgetStyle name="Non-printing characters custom color" styleID="0" fgColor="{{ overlay0.hex }}" />
     </GlobalStyles>
 </NotepadPlus>

--- a/templates/editor.tera
+++ b/templates/editor.tera
@@ -570,46 +570,60 @@ whiskers:
         </LexerType>
     </LexerStyles>
     <GlobalStyles>
-        <!-- Attention : Don't modify the name of styleID="0" -->
-        <WidgetStyle name="Global override" styleID="0" fgColor="{{ text.hex }}" bgColor="{{ base.hex }}" fontName="Consolas" fontStyle="0" fontSize="10" />
+        <!-- Attention : Don't modify the name of any styleID="0" -->
         <WidgetStyle name="Default Style" styleID="32" fgColor="{{ text.hex }}" bgColor="{{ base.hex }}" fontName="Consolas" fontStyle="0" fontSize="10" />
         <WidgetStyle name="Indent guideline style" styleID="37" fgColor="{{ blue.hex }}" bgColor="{{ base.hex }}" fontName="" fontStyle="0" fontSize="" />
         <WidgetStyle name="Brace highlight style" styleID="34" fgColor="{{ text.hex }}" bgColor="{{ selected.hex }}" fontName="" fontStyle="1" fontSize="10" />
-        <WidgetStyle name="Bad brace colour" styleID="35" fgColor="{{ text.hex }}" bgColor="{{ red.hex }}" fontName="" fontStyle="0" fontSize="" />
-        <WidgetStyle name="Current line background colour" styleID="0" bgColor="{{ line.hex }}" fgColor="{{ text.hex }}" fontSize="" fontStyle="0" />
+        <WidgetStyle name="Bad brace colour" styleID="35" fgColor="{{ crust.hex }}" bgColor="{{ red.hex }}" fontName="" fontStyle="0" fontSize="" />
+        <WidgetStyle name="Current line background colour" styleID="0" bgColor="{{ line.hex }}" fgColor="{{ text.hex }}" fontSize="" fontStyle="" />
+        <!-- In below rule 'fgColor' attribute for 'Selected text colour' can be unlocked with a enableSelectFgColor.xml file -->
         <WidgetStyle name="Selected text colour" styleID="0" bgColor="{{ selected.hex }}" fontStyle="0" />
         <WidgetStyle name="Multi-selected text color" styleID="0" bgColor="{{ selected.hex }}" />
-        <WidgetStyle name="Caret colour" styleID="2069" fgColor="{{ rosewater.hex }}" bgColor="{{ base.hex }}" fontStyle="0" />
+        <WidgetStyle name="Caret colour" styleID="2069" fgColor="{{ rosewater.hex }}" />
         <WidgetStyle name="Multi-edit carets color" styleID="0" fgColor="{{ rosewater.hex }}" />
-        <WidgetStyle name="Edge colour" styleID="0" fgColor="{{ text.hex }}" bgColor="{{ base.hex }}" fontSize="" fontStyle="0" />
+        <WidgetStyle name="Edge colour" styleID="0" fgColor="{{ text.hex }}" />
         <WidgetStyle name="Line number margin" styleID="33" fgColor="{{ overlay1.hex }}" bgColor="{{ base.hex }}" fontName="" fontStyle="0" fontSize="" />
         <WidgetStyle name="Bookmark margin" styleID="0" bgColor="{{ base.hex }}" />
         <WidgetStyle name="Change History margin" styleID="0" bgColor="{{ base.hex }}" />
-        <WidgetStyle name="Fold" styleID="0" fgColor="{{ mauve.hex }}" bgColor="{{ base.hex }}" fontStyle="0" fontSize="" />
-        <WidgetStyle name="Fold active" styleID="0" fgColor="{{ mauve.hex }}" fontStyle="0" fontSize="" bgColor="{{ base.hex }}" />
-        <WidgetStyle name="Fold margin" styleID="0" fgColor="{{ base.hex }}" bgColor="{{ base.hex }}" fontStyle="0" fontSize="" />
-        <WidgetStyle name="White space symbol" styleID="0" fgColor="{{ blue.hex }}" bgColor="{{ base.hex }}" fontStyle="0" fontSize="" />
-        <WidgetStyle name="Smart HighLighting" styleID="29" bgColor="{{ overlay2.hex }}" fgColor="{{ text.hex }}" fontSize="" fontStyle="1" />
-        <WidgetStyle name="Find Mark Style" styleID="31" bgColor="{{ red.hex }}"></WidgetStyle>
-        <WidgetStyle name="Mark Style 1" styleID="25" bgColor="{{ sapphire.hex }}"></WidgetStyle>
-        <WidgetStyle name="Mark Style 2" styleID="24" bgColor="{{ peach.hex }}"></WidgetStyle>
-        <WidgetStyle name="Mark Style 3" styleID="23" bgColor="{{ yellow.hex }}"></WidgetStyle>
-        <WidgetStyle name="Mark Style 4" styleID="22" bgColor="{{ mauve.hex }}"></WidgetStyle>
-        <WidgetStyle name="Mark Style 5" styleID="21" bgColor="{{ green.hex }}"></WidgetStyle>
-        <WidgetStyle name="Incremental highlight all" styleID="28" bgColor="{{ blue.hex }}" />
-        <WidgetStyle name="Tags match highlighting" styleID="27" bgColor="{{ selected.hex }}" fgColor="{{ text.hex }}" fontStyle="0" />
-        <WidgetStyle name="Tags attribute" styleID="26" bgColor="{{ base.hex }}" fgColor="{{ text.hex }}" fontStyle="0" />
-        <WidgetStyle name="Active tab focused indicator" styleID="0" fgColor="{{ lavender.hex }}" />
-        <WidgetStyle name="Active tab unfocused indicator" styleID="0" fgColor="{{ sapphire.hex }}" />
-        <WidgetStyle name="Active tab text" styleID="0" fgColor="{{ lavender.hex }}" />
-        <WidgetStyle name="Inactive tabs" styleID="0" fgColor="{{ subtext1.hex }}" bgColor="{{ crust.hex }}" />
-        <WidgetStyle name="URL hovered" styleID="0" fgColor="{{ sky.hex }}" bgColor="{{ base.hex }}" fontStyle="0" />
-        <WidgetStyle name="Document map" styleID="0" fgColor="{{ sky.hex }}" bgColor="{{ surface2.hex }}" />
-        <WidgetStyle name="EOL custom color" styleID="0" fgColor="{{ subtext0.hex }}" />
-        <WidgetStyle name="Non-printing characters custom color" styleID="0" fgColor="{{ overlay0.hex }}" />
         <WidgetStyle name="Change History modified" styleID="0" fgColor="{{ peach.hex }}" bgColor="{{ peach.hex }}" />
         <WidgetStyle name="Change History revert modified" styleID="0" fgColor="{{ lavender.hex }}" bgColor="{{ lavender.hex }}" />
         <WidgetStyle name="Change History revert origin" styleID="0" fgColor="{{ teal.hex }}" bgColor="{{ teal.hex }}" />
         <WidgetStyle name="Change History saved" styleID="0" fgColor="{{ green.hex }}" bgColor="{{ green.hex }}" />
+        <WidgetStyle name="Fold" styleID="0" fgColor="{{ mauve.hex }}" bgColor="{{ base.hex }}" />
+        <WidgetStyle name="Fold active" styleID="0" fgColor="{{ mauve.hex }}" />
+        <WidgetStyle name="Fold margin" styleID="0" fgColor="{{ base.hex }}" bgColor="{{ base.hex }}" />
+        <WidgetStyle name="White space symbol" styleID="0" fgColor="{{ overlay2.hex }}" bgColor="{{ base.hex }}" fontstyle="0" fontSize="" />
+        <WidgetStyle name="Smart Highlighting" styleID="29" bgColor="{{ overlay0.hex }}" />
+        <WidgetStyle name="Find Mark Style" styleID="31" bgColor="{{ maroon.hex }}" />
+        <WidgetStyle name="Find status: Not found" styleID="0" fgColor="{{ red.hex }}" />
+        <WidgetStyle name="Find status: Message" styleID="0" fgColor="{{ teal.hex }}" />
+        <WidgetStyle name="Find status: Search end reached" styleID="0" fgColor="{{ yellow.hex }}" />
+        <WidgetStyle name="Mark Style 1" styleID="25" bgColor="{{ sapphire.hex }}" />
+        <WidgetStyle name="Mark Style 2" styleID="24" bgColor="{{ maroon.hex }}" />
+        <WidgetStyle name="Mark Style 3" styleID="23" bgColor="{{ yellow.hex }}" />
+        <WidgetStyle name="Mark Style 4" styleID="22" bgColor="{{ mauve.hex }}" />
+        <WidgetStyle name="Mark Style 5" styleID="21" bgColor="{{ green.hex }}" />
+        <WidgetStyle name="Incremental highlight all" styleID="28" bgColor="{{ blue.hex }}" />
+        <WidgetStyle name="Tags match highlighting" styleID="27" bgColor="{{ selected.hex }}" />
+        <WidgetStyle name="Tags attribute" styleID="26" bgColor="{{ base.hex }}" />
+        <WidgetStyle name="Active tab focused indicator" styleID="0" fgColor="{{ lavender.hex }}" />
+        <WidgetStyle name="Active tab unfocused indicator" styleID="0" fgColor="{{ overlay1.hex }}" />
+        <WidgetStyle name="Active tab text" styleID="0" fgColor="{{ text.hex }}" />
+        <WidgetStyle name="Inactive tabs" styleID="0" fgColor="{{ subtext1.hex }}" bgColor="{{ crust.hex }}" />
+        <WidgetStyle name="Tab color 1" styleID="0" bgColor="{{ peach.hex }}" />
+        <WidgetStyle name="Tab color 2" styleID="0" bgColor="{{ green.hex }}" />
+        <WidgetStyle name="Tab color 3" styleID="0" bgColor="{{ pink.hex }}" />
+        <WidgetStyle name="Tab color 4" styleID="0" bgColor="{{ blue.hex }}" />
+        <WidgetStyle name="Tab color 5" styleID="0" bgColor="{{ red.hex }}" />
+        <WidgetStyle name="Tab color dark mode 1" styleID="0" bgColor="{{ peach.hex }}" />
+        <WidgetStyle name="Tab color dark mode 2" styleID="0" bgColor="{{ green.hex }}" />
+        <WidgetStyle name="Tab color dark mode 3" styleID="0" bgColor="{{ pink.hex }}" />
+        <WidgetStyle name="Tab color dark mode 4" styleID="0" bgColor="{{ blue.hex }}" />
+        <WidgetStyle name="Tab color dark mode 5" styleID="0" bgColor="{{ red.hex }}" />
+        <WidgetStyle name="URL hovered" styleID="0" fgColor="{{ sky.hex }}" bgColor="{{ base.hex }}" fontStyle="0" />
+        <WidgetStyle name="Document map" styleID="0" fgColor="{{ sky.hex }}" bgColor="{{ surface2.hex }}" />
+        <WidgetStyle name="EOL custom color" styleID="0" fgColor="{{ subtext0.hex }}" />
+        <WidgetStyle name="Non-printing characters custom color" styleID="0" fgColor="{{ overlay0.hex }}" />
+        <WidgetStyle name="Global override" styleID="0" fgColor="{{ text.hex }}" bgColor="{{ base.hex}}" fontName="" fontStyle="0" fontSize="10" />
     </GlobalStyles>
 </NotepadPlus>

--- a/templates/ui.tera
+++ b/templates/ui.tera
@@ -3,10 +3,11 @@ whiskers:
   version: 2.5.1
   filename: "ui-theme.md"
 ---
-{% macro bgr(c) -%}
+{%- macro bgr(c) -%}
 {{ (c.rgb.b * 65536) + (c.rgb.g * 256) + c.rgb.r }}
-{%- endmacro bgr %}
+{%- endmacro bgr -%}
 # Changing UI Colors
+
 Notepad++ has limited support for customizing the UI elements.
 Some elements are controlled by the Windows theme (menu dropdowns, scrollbars, etc.) and can't be changed.
 
@@ -22,7 +23,7 @@ Replace the line beginning with `<GUIConfig name="DarkMode">` with the desired f
 <summary>{{ flavor.emoji }} {{ flavor.name }}</summary>
 
 ```xml
-<GUIConfig name="DarkMode" enable="yes" colorTone="32" customColorTop="{{ self::bgr(c=l.base) }}" customColorMenuHotTrack="{{ self::bgr(c=l.surface1) }}" customColorActive="{{ self::bgr(c=l.mantle) }}" customColorMain="{{ self::bgr(c=l.crust) }}" customColorError="{{ self::bgr(c=l.red) }}" customColorText="{{ self::bgr(c=l.text) }}" customColorDarkText="{{ self::bgr(c=l.subtext1) }}" customColorDisabledText="{{ self::bgr(c=l.subtext0) }}" customColorLinkText="{{ self::bgr(c=l.blue)}}" customColorEdge="{{ self::bgr(c=l.overlay1) }}" customColorHotEdge="{{ self::bgr(c=l.overlay2) }}" customColorDisabledEdge="{{ self::bgr(c=l.overlay0) }}" enableWindowsMode="no" darkThemeName="catppuccin-{{ flavor.identifier }}.xml" darkToolBarIconSet="2" darkTabIconSet="2" darkTabUseTheme="no" lightThemeName="catppuccin-{{ flavor.identifier }}.xml" lightToolBarIconSet="4" lightTabIconSet="0" lightTabUseTheme="yes" />
+<GUIConfig name="DarkMode" enable="yes" colorTone="32" customColorTop="{{ self::bgr(c=l.base) }}" customColorMenuHotTrack="{{ self::bgr(c=l.surface1) }}" customColorActive="{{ self::bgr(c=l.mantle) }}" customColorMain="{{ self::bgr(c=l.crust) }}" customColorError="{{ self::bgr(c=l.red) }}" customColorText="{{ self::bgr(c=l.text) }}" customColorDarkText="{{ self::bgr(c=l.subtext1) }}" customColorDisabledText="{{ self::bgr(c=l.subtext0) }}" customColorLinkText="{{ self::bgr(c=l.blue)}}" customColorEdge="{{ self::bgr(c=l.overlay1) }}" customColorHotEdge="{{ self::bgr(c=l.overlay2) }}" customColorDisabledEdge="{{ self::bgr(c=l.overlay0) }}" enableWindowsMode="no" darkThemeName="catppuccin-{{ flavor.identifier }}.xml" darkToolBarIconSet="2" darkTabIconSet="2" darkTabUseTheme="yes" lightThemeName="catppuccin-{{ flavor.identifier }}.xml" lightToolBarIconSet="4" lightTabIconSet="0" lightTabUseTheme="yes" />
 ```
 
 </details>

--- a/themes/catppuccin-frappe.xml
+++ b/themes/catppuccin-frappe.xml
@@ -568,16 +568,17 @@
         <WidgetStyle name="Bad brace colour" styleID="35" fgColor="C6D0F5" bgColor="E78284" fontName="" fontStyle="0" fontSize="" />
         <WidgetStyle name="Current line background colour" styleID="0" bgColor="3F4458" fgColor="C6D0F5" fontSize="" fontStyle="0" />
         <WidgetStyle name="Selected text colour" styleID="0" bgColor="4F5369" fontStyle="0" />
+        <WidgetStyle name="Multi-selected text color" styleID="0" bgColor="4F5369" />
         <WidgetStyle name="Caret colour" styleID="2069" fgColor="F2D5CF" bgColor="303446" fontStyle="0" />
+        <WidgetStyle name="Multi-edit carets color" styleID="0" fgColor="F2D5CF" />
         <WidgetStyle name="Edge colour" styleID="0" fgColor="C6D0F5" bgColor="303446" fontSize="" fontStyle="0" />
         <WidgetStyle name="Line number margin" styleID="33" fgColor="838BA7" bgColor="303446" fontName="" fontStyle="0" fontSize="" />
+        <WidgetStyle name="Bookmark margin" styleID="0" bgColor="303446" />
+        <WidgetStyle name="Change History margin" styleID="0" bgColor="303446" />
         <WidgetStyle name="Fold" styleID="0" fgColor="CA9EE6" bgColor="303446" fontStyle="0" fontSize="" />
         <WidgetStyle name="Fold active" styleID="0" fgColor="CA9EE6" fontStyle="0" fontSize="" bgColor="303446" />
         <WidgetStyle name="Fold margin" styleID="0" fgColor="303446" bgColor="303446" fontStyle="0" fontSize="" />
         <WidgetStyle name="White space symbol" styleID="0" fgColor="8CAAEE" bgColor="303446" fontStyle="0" fontSize="" />
-        <WidgetStyle name="URL hovered" styleID="0" fgColor="99D1DB" bgColor="303446" fontStyle="0" />
-        <WidgetStyle name="Tags attribute" styleID="26" bgColor="303446" fgColor="C6D0F5" fontStyle="0" />
-        <WidgetStyle name="Tags match highlighting" styleID="27" bgColor="4F5369" fgColor="C6D0F5" fontStyle="0" />
         <WidgetStyle name="Smart HighLighting" styleID="29" bgColor="949CBB" fgColor="C6D0F5" fontSize="" fontStyle="1" />
         <WidgetStyle name="Find Mark Style" styleID="31" bgColor="E78284"></WidgetStyle>
         <WidgetStyle name="Mark Style 1" styleID="25" bgColor="85C1DC"></WidgetStyle>
@@ -585,12 +586,20 @@
         <WidgetStyle name="Mark Style 3" styleID="23" bgColor="E5C890"></WidgetStyle>
         <WidgetStyle name="Mark Style 4" styleID="22" bgColor="CA9EE6"></WidgetStyle>
         <WidgetStyle name="Mark Style 5" styleID="21" bgColor="A6D189"></WidgetStyle>
-        <WidgetStyle name="Active tab focused indicator" styleID="0" fgColor="BABBF1" fontStyle="0" />
+        <WidgetStyle name="Incremental highlight all" styleID="28" bgColor="8CAAEE" />
+        <WidgetStyle name="Tags match highlighting" styleID="27" bgColor="4F5369" fgColor="C6D0F5" fontStyle="0" />
+        <WidgetStyle name="Tags attribute" styleID="26" bgColor="303446" fgColor="C6D0F5" fontStyle="0" />
+        <WidgetStyle name="Active tab focused indicator" styleID="0" fgColor="BABBF1" />
+        <WidgetStyle name="Active tab unfocused indicator" styleID="0" fgColor="85C1DC" />
+        <WidgetStyle name="Active tab text" styleID="0" fgColor="BABBF1" />
+        <WidgetStyle name="Inactive tabs" styleID="0" fgColor="B5BFE2" bgColor="232634" />
+        <WidgetStyle name="URL hovered" styleID="0" fgColor="99D1DB" bgColor="303446" fontStyle="0" />
+        <WidgetStyle name="Document map" styleID="0" fgColor="99D1DB" bgColor="626880" />
+        <WidgetStyle name="EOL custom color" styleID="0" fgColor="A5ADCE" />
+        <WidgetStyle name="Non-printing characters custom color" styleID="0" fgColor="737994" />
         <WidgetStyle name="Change History modified" styleID="0" fgColor="EF9F76" bgColor="EF9F76" />
         <WidgetStyle name="Change History revert modified" styleID="0" fgColor="BABBF1" bgColor="BABBF1" />
         <WidgetStyle name="Change History revert origin" styleID="0" fgColor="81C8BE" bgColor="81C8BE" />
         <WidgetStyle name="Change History saved" styleID="0" fgColor="A6D189" bgColor="A6D189" />
-        <WidgetStyle name="EOL custom color" styleID="0" fgColor="A5ADCE" />
-        <WidgetStyle name="Non-printing characters custom color" styleID="0" fgColor="737994" />
     </GlobalStyles>
 </NotepadPlus>

--- a/themes/catppuccin-frappe.xml
+++ b/themes/catppuccin-frappe.xml
@@ -560,46 +560,60 @@
         </LexerType>
     </LexerStyles>
     <GlobalStyles>
-        <!-- Attention : Don't modify the name of styleID="0" -->
-        <WidgetStyle name="Global override" styleID="0" fgColor="C6D0F5" bgColor="303446" fontName="Consolas" fontStyle="0" fontSize="10" />
+        <!-- Attention : Don't modify the name of any styleID="0" -->
         <WidgetStyle name="Default Style" styleID="32" fgColor="C6D0F5" bgColor="303446" fontName="Consolas" fontStyle="0" fontSize="10" />
         <WidgetStyle name="Indent guideline style" styleID="37" fgColor="8CAAEE" bgColor="303446" fontName="" fontStyle="0" fontSize="" />
         <WidgetStyle name="Brace highlight style" styleID="34" fgColor="C6D0F5" bgColor="4F5369" fontName="" fontStyle="1" fontSize="10" />
-        <WidgetStyle name="Bad brace colour" styleID="35" fgColor="C6D0F5" bgColor="E78284" fontName="" fontStyle="0" fontSize="" />
-        <WidgetStyle name="Current line background colour" styleID="0" bgColor="3F4458" fgColor="C6D0F5" fontSize="" fontStyle="0" />
+        <WidgetStyle name="Bad brace colour" styleID="35" fgColor="232634" bgColor="E78284" fontName="" fontStyle="0" fontSize="" />
+        <WidgetStyle name="Current line background colour" styleID="0" bgColor="3F4458" fgColor="C6D0F5" fontSize="" fontStyle="" />
+        <!-- In below rule 'fgColor' attribute for 'Selected text colour' can be unlocked with a enableSelectFgColor.xml file -->
         <WidgetStyle name="Selected text colour" styleID="0" bgColor="4F5369" fontStyle="0" />
         <WidgetStyle name="Multi-selected text color" styleID="0" bgColor="4F5369" />
-        <WidgetStyle name="Caret colour" styleID="2069" fgColor="F2D5CF" bgColor="303446" fontStyle="0" />
+        <WidgetStyle name="Caret colour" styleID="2069" fgColor="F2D5CF" />
         <WidgetStyle name="Multi-edit carets color" styleID="0" fgColor="F2D5CF" />
-        <WidgetStyle name="Edge colour" styleID="0" fgColor="C6D0F5" bgColor="303446" fontSize="" fontStyle="0" />
+        <WidgetStyle name="Edge colour" styleID="0" fgColor="C6D0F5" />
         <WidgetStyle name="Line number margin" styleID="33" fgColor="838BA7" bgColor="303446" fontName="" fontStyle="0" fontSize="" />
         <WidgetStyle name="Bookmark margin" styleID="0" bgColor="303446" />
         <WidgetStyle name="Change History margin" styleID="0" bgColor="303446" />
-        <WidgetStyle name="Fold" styleID="0" fgColor="CA9EE6" bgColor="303446" fontStyle="0" fontSize="" />
-        <WidgetStyle name="Fold active" styleID="0" fgColor="CA9EE6" fontStyle="0" fontSize="" bgColor="303446" />
-        <WidgetStyle name="Fold margin" styleID="0" fgColor="303446" bgColor="303446" fontStyle="0" fontSize="" />
-        <WidgetStyle name="White space symbol" styleID="0" fgColor="8CAAEE" bgColor="303446" fontStyle="0" fontSize="" />
-        <WidgetStyle name="Smart HighLighting" styleID="29" bgColor="949CBB" fgColor="C6D0F5" fontSize="" fontStyle="1" />
-        <WidgetStyle name="Find Mark Style" styleID="31" bgColor="E78284"></WidgetStyle>
-        <WidgetStyle name="Mark Style 1" styleID="25" bgColor="85C1DC"></WidgetStyle>
-        <WidgetStyle name="Mark Style 2" styleID="24" bgColor="EF9F76"></WidgetStyle>
-        <WidgetStyle name="Mark Style 3" styleID="23" bgColor="E5C890"></WidgetStyle>
-        <WidgetStyle name="Mark Style 4" styleID="22" bgColor="CA9EE6"></WidgetStyle>
-        <WidgetStyle name="Mark Style 5" styleID="21" bgColor="A6D189"></WidgetStyle>
-        <WidgetStyle name="Incremental highlight all" styleID="28" bgColor="8CAAEE" />
-        <WidgetStyle name="Tags match highlighting" styleID="27" bgColor="4F5369" fgColor="C6D0F5" fontStyle="0" />
-        <WidgetStyle name="Tags attribute" styleID="26" bgColor="303446" fgColor="C6D0F5" fontStyle="0" />
-        <WidgetStyle name="Active tab focused indicator" styleID="0" fgColor="BABBF1" />
-        <WidgetStyle name="Active tab unfocused indicator" styleID="0" fgColor="85C1DC" />
-        <WidgetStyle name="Active tab text" styleID="0" fgColor="BABBF1" />
-        <WidgetStyle name="Inactive tabs" styleID="0" fgColor="B5BFE2" bgColor="232634" />
-        <WidgetStyle name="URL hovered" styleID="0" fgColor="99D1DB" bgColor="303446" fontStyle="0" />
-        <WidgetStyle name="Document map" styleID="0" fgColor="99D1DB" bgColor="626880" />
-        <WidgetStyle name="EOL custom color" styleID="0" fgColor="A5ADCE" />
-        <WidgetStyle name="Non-printing characters custom color" styleID="0" fgColor="737994" />
         <WidgetStyle name="Change History modified" styleID="0" fgColor="EF9F76" bgColor="EF9F76" />
         <WidgetStyle name="Change History revert modified" styleID="0" fgColor="BABBF1" bgColor="BABBF1" />
         <WidgetStyle name="Change History revert origin" styleID="0" fgColor="81C8BE" bgColor="81C8BE" />
         <WidgetStyle name="Change History saved" styleID="0" fgColor="A6D189" bgColor="A6D189" />
+        <WidgetStyle name="Fold" styleID="0" fgColor="CA9EE6" bgColor="303446" />
+        <WidgetStyle name="Fold active" styleID="0" fgColor="CA9EE6" />
+        <WidgetStyle name="Fold margin" styleID="0" fgColor="303446" bgColor="303446" />
+        <WidgetStyle name="White space symbol" styleID="0" fgColor="949CBB" bgColor="303446" fontstyle="0" fontSize="" />
+        <WidgetStyle name="Smart Highlighting" styleID="29" bgColor="737994" />
+        <WidgetStyle name="Find Mark Style" styleID="31" bgColor="EA999C" />
+        <WidgetStyle name="Find status: Not found" styleID="0" fgColor="E78284" />
+        <WidgetStyle name="Find status: Message" styleID="0" fgColor="81C8BE" />
+        <WidgetStyle name="Find status: Search end reached" styleID="0" fgColor="E5C890" />
+        <WidgetStyle name="Mark Style 1" styleID="25" bgColor="85C1DC" />
+        <WidgetStyle name="Mark Style 2" styleID="24" bgColor="EA999C" />
+        <WidgetStyle name="Mark Style 3" styleID="23" bgColor="E5C890" />
+        <WidgetStyle name="Mark Style 4" styleID="22" bgColor="CA9EE6" />
+        <WidgetStyle name="Mark Style 5" styleID="21" bgColor="A6D189" />
+        <WidgetStyle name="Incremental highlight all" styleID="28" bgColor="8CAAEE" />
+        <WidgetStyle name="Tags match highlighting" styleID="27" bgColor="4F5369" />
+        <WidgetStyle name="Tags attribute" styleID="26" bgColor="303446" />
+        <WidgetStyle name="Active tab focused indicator" styleID="0" fgColor="BABBF1" />
+        <WidgetStyle name="Active tab unfocused indicator" styleID="0" fgColor="838BA7" />
+        <WidgetStyle name="Active tab text" styleID="0" fgColor="C6D0F5" />
+        <WidgetStyle name="Inactive tabs" styleID="0" fgColor="B5BFE2" bgColor="232634" />
+        <WidgetStyle name="Tab color 1" styleID="0" bgColor="EF9F76" />
+        <WidgetStyle name="Tab color 2" styleID="0" bgColor="A6D189" />
+        <WidgetStyle name="Tab color 3" styleID="0" bgColor="F4B8E4" />
+        <WidgetStyle name="Tab color 4" styleID="0" bgColor="8CAAEE" />
+        <WidgetStyle name="Tab color 5" styleID="0" bgColor="E78284" />
+        <WidgetStyle name="Tab color dark mode 1" styleID="0" bgColor="EF9F76" />
+        <WidgetStyle name="Tab color dark mode 2" styleID="0" bgColor="A6D189" />
+        <WidgetStyle name="Tab color dark mode 3" styleID="0" bgColor="F4B8E4" />
+        <WidgetStyle name="Tab color dark mode 4" styleID="0" bgColor="8CAAEE" />
+        <WidgetStyle name="Tab color dark mode 5" styleID="0" bgColor="E78284" />
+        <WidgetStyle name="URL hovered" styleID="0" fgColor="99D1DB" bgColor="303446" fontStyle="0" />
+        <WidgetStyle name="Document map" styleID="0" fgColor="99D1DB" bgColor="626880" />
+        <WidgetStyle name="EOL custom color" styleID="0" fgColor="A5ADCE" />
+        <WidgetStyle name="Non-printing characters custom color" styleID="0" fgColor="737994" />
+        <WidgetStyle name="Global override" styleID="0" fgColor="C6D0F5" bgColor="303446" fontName="" fontStyle="0" fontSize="10" />
     </GlobalStyles>
 </NotepadPlus>

--- a/themes/catppuccin-latte.xml
+++ b/themes/catppuccin-latte.xml
@@ -560,46 +560,60 @@
         </LexerType>
     </LexerStyles>
     <GlobalStyles>
-        <!-- Attention : Don't modify the name of styleID="0" -->
-        <WidgetStyle name="Global override" styleID="0" fgColor="4C4F69" bgColor="EFF1F5" fontName="Consolas" fontStyle="0" fontSize="10" />
+        <!-- Attention : Don't modify the name of any styleID="0" -->
         <WidgetStyle name="Default Style" styleID="32" fgColor="4C4F69" bgColor="EFF1F5" fontName="Consolas" fontStyle="0" fontSize="10" />
         <WidgetStyle name="Indent guideline style" styleID="37" fgColor="1E66F5" bgColor="EFF1F5" fontName="" fontStyle="0" fontSize="" />
         <WidgetStyle name="Brace highlight style" styleID="34" fgColor="4C4F69" bgColor="CCCED7" fontName="" fontStyle="1" fontSize="10" />
-        <WidgetStyle name="Bad brace colour" styleID="35" fgColor="4C4F69" bgColor="D20F39" fontName="" fontStyle="0" fontSize="" />
-        <WidgetStyle name="Current line background colour" styleID="0" bgColor="DFE0E7" fgColor="4C4F69" fontSize="" fontStyle="0" />
+        <WidgetStyle name="Bad brace colour" styleID="35" fgColor="DCE0E8" bgColor="D20F39" fontName="" fontStyle="0" fontSize="" />
+        <WidgetStyle name="Current line background colour" styleID="0" bgColor="DFE0E7" fgColor="4C4F69" fontSize="" fontStyle="" />
+        <!-- In below rule 'fgColor' attribute for 'Selected text colour' can be unlocked with a enableSelectFgColor.xml file -->
         <WidgetStyle name="Selected text colour" styleID="0" bgColor="CCCED7" fontStyle="0" />
         <WidgetStyle name="Multi-selected text color" styleID="0" bgColor="CCCED7" />
-        <WidgetStyle name="Caret colour" styleID="2069" fgColor="DC8A78" bgColor="EFF1F5" fontStyle="0" />
+        <WidgetStyle name="Caret colour" styleID="2069" fgColor="DC8A78" />
         <WidgetStyle name="Multi-edit carets color" styleID="0" fgColor="DC8A78" />
-        <WidgetStyle name="Edge colour" styleID="0" fgColor="4C4F69" bgColor="EFF1F5" fontSize="" fontStyle="0" />
+        <WidgetStyle name="Edge colour" styleID="0" fgColor="4C4F69" />
         <WidgetStyle name="Line number margin" styleID="33" fgColor="8C8FA1" bgColor="EFF1F5" fontName="" fontStyle="0" fontSize="" />
         <WidgetStyle name="Bookmark margin" styleID="0" bgColor="EFF1F5" />
         <WidgetStyle name="Change History margin" styleID="0" bgColor="EFF1F5" />
-        <WidgetStyle name="Fold" styleID="0" fgColor="8839EF" bgColor="EFF1F5" fontStyle="0" fontSize="" />
-        <WidgetStyle name="Fold active" styleID="0" fgColor="8839EF" fontStyle="0" fontSize="" bgColor="EFF1F5" />
-        <WidgetStyle name="Fold margin" styleID="0" fgColor="EFF1F5" bgColor="EFF1F5" fontStyle="0" fontSize="" />
-        <WidgetStyle name="White space symbol" styleID="0" fgColor="1E66F5" bgColor="EFF1F5" fontStyle="0" fontSize="" />
-        <WidgetStyle name="Smart HighLighting" styleID="29" bgColor="7C7F93" fgColor="4C4F69" fontSize="" fontStyle="1" />
-        <WidgetStyle name="Find Mark Style" styleID="31" bgColor="D20F39"></WidgetStyle>
-        <WidgetStyle name="Mark Style 1" styleID="25" bgColor="209FB5"></WidgetStyle>
-        <WidgetStyle name="Mark Style 2" styleID="24" bgColor="FE640B"></WidgetStyle>
-        <WidgetStyle name="Mark Style 3" styleID="23" bgColor="DF8E1D"></WidgetStyle>
-        <WidgetStyle name="Mark Style 4" styleID="22" bgColor="8839EF"></WidgetStyle>
-        <WidgetStyle name="Mark Style 5" styleID="21" bgColor="40A02B"></WidgetStyle>
-        <WidgetStyle name="Incremental highlight all" styleID="28" bgColor="1E66F5" />
-        <WidgetStyle name="Tags match highlighting" styleID="27" bgColor="CCCED7" fgColor="4C4F69" fontStyle="0" />
-        <WidgetStyle name="Tags attribute" styleID="26" bgColor="EFF1F5" fgColor="4C4F69" fontStyle="0" />
-        <WidgetStyle name="Active tab focused indicator" styleID="0" fgColor="7287FD" />
-        <WidgetStyle name="Active tab unfocused indicator" styleID="0" fgColor="209FB5" />
-        <WidgetStyle name="Active tab text" styleID="0" fgColor="7287FD" />
-        <WidgetStyle name="Inactive tabs" styleID="0" fgColor="5C5F77" bgColor="DCE0E8" />
-        <WidgetStyle name="URL hovered" styleID="0" fgColor="04A5E5" bgColor="EFF1F5" fontStyle="0" />
-        <WidgetStyle name="Document map" styleID="0" fgColor="04A5E5" bgColor="ACB0BE" />
-        <WidgetStyle name="EOL custom color" styleID="0" fgColor="6C6F85" />
-        <WidgetStyle name="Non-printing characters custom color" styleID="0" fgColor="9CA0B0" />
         <WidgetStyle name="Change History modified" styleID="0" fgColor="FE640B" bgColor="FE640B" />
         <WidgetStyle name="Change History revert modified" styleID="0" fgColor="7287FD" bgColor="7287FD" />
         <WidgetStyle name="Change History revert origin" styleID="0" fgColor="179299" bgColor="179299" />
         <WidgetStyle name="Change History saved" styleID="0" fgColor="40A02B" bgColor="40A02B" />
+        <WidgetStyle name="Fold" styleID="0" fgColor="8839EF" bgColor="EFF1F5" />
+        <WidgetStyle name="Fold active" styleID="0" fgColor="8839EF" />
+        <WidgetStyle name="Fold margin" styleID="0" fgColor="EFF1F5" bgColor="EFF1F5" />
+        <WidgetStyle name="White space symbol" styleID="0" fgColor="7C7F93" bgColor="EFF1F5" fontstyle="0" fontSize="" />
+        <WidgetStyle name="Smart Highlighting" styleID="29" bgColor="9CA0B0" />
+        <WidgetStyle name="Find Mark Style" styleID="31" bgColor="E64553" />
+        <WidgetStyle name="Find status: Not found" styleID="0" fgColor="D20F39" />
+        <WidgetStyle name="Find status: Message" styleID="0" fgColor="179299" />
+        <WidgetStyle name="Find status: Search end reached" styleID="0" fgColor="DF8E1D" />
+        <WidgetStyle name="Mark Style 1" styleID="25" bgColor="209FB5" />
+        <WidgetStyle name="Mark Style 2" styleID="24" bgColor="E64553" />
+        <WidgetStyle name="Mark Style 3" styleID="23" bgColor="DF8E1D" />
+        <WidgetStyle name="Mark Style 4" styleID="22" bgColor="8839EF" />
+        <WidgetStyle name="Mark Style 5" styleID="21" bgColor="40A02B" />
+        <WidgetStyle name="Incremental highlight all" styleID="28" bgColor="1E66F5" />
+        <WidgetStyle name="Tags match highlighting" styleID="27" bgColor="CCCED7" />
+        <WidgetStyle name="Tags attribute" styleID="26" bgColor="EFF1F5" />
+        <WidgetStyle name="Active tab focused indicator" styleID="0" fgColor="7287FD" />
+        <WidgetStyle name="Active tab unfocused indicator" styleID="0" fgColor="8C8FA1" />
+        <WidgetStyle name="Active tab text" styleID="0" fgColor="4C4F69" />
+        <WidgetStyle name="Inactive tabs" styleID="0" fgColor="5C5F77" bgColor="DCE0E8" />
+        <WidgetStyle name="Tab color 1" styleID="0" bgColor="FE640B" />
+        <WidgetStyle name="Tab color 2" styleID="0" bgColor="40A02B" />
+        <WidgetStyle name="Tab color 3" styleID="0" bgColor="EA76CB" />
+        <WidgetStyle name="Tab color 4" styleID="0" bgColor="1E66F5" />
+        <WidgetStyle name="Tab color 5" styleID="0" bgColor="D20F39" />
+        <WidgetStyle name="Tab color dark mode 1" styleID="0" bgColor="FE640B" />
+        <WidgetStyle name="Tab color dark mode 2" styleID="0" bgColor="40A02B" />
+        <WidgetStyle name="Tab color dark mode 3" styleID="0" bgColor="EA76CB" />
+        <WidgetStyle name="Tab color dark mode 4" styleID="0" bgColor="1E66F5" />
+        <WidgetStyle name="Tab color dark mode 5" styleID="0" bgColor="D20F39" />
+        <WidgetStyle name="URL hovered" styleID="0" fgColor="04A5E5" bgColor="EFF1F5" fontStyle="0" />
+        <WidgetStyle name="Document map" styleID="0" fgColor="04A5E5" bgColor="ACB0BE" />
+        <WidgetStyle name="EOL custom color" styleID="0" fgColor="6C6F85" />
+        <WidgetStyle name="Non-printing characters custom color" styleID="0" fgColor="9CA0B0" />
+        <WidgetStyle name="Global override" styleID="0" fgColor="4C4F69" bgColor="EFF1F5" fontName="" fontStyle="0" fontSize="10" />
     </GlobalStyles>
 </NotepadPlus>

--- a/themes/catppuccin-latte.xml
+++ b/themes/catppuccin-latte.xml
@@ -568,16 +568,17 @@
         <WidgetStyle name="Bad brace colour" styleID="35" fgColor="4C4F69" bgColor="D20F39" fontName="" fontStyle="0" fontSize="" />
         <WidgetStyle name="Current line background colour" styleID="0" bgColor="DFE0E7" fgColor="4C4F69" fontSize="" fontStyle="0" />
         <WidgetStyle name="Selected text colour" styleID="0" bgColor="CCCED7" fontStyle="0" />
+        <WidgetStyle name="Multi-selected text color" styleID="0" bgColor="CCCED7" />
         <WidgetStyle name="Caret colour" styleID="2069" fgColor="DC8A78" bgColor="EFF1F5" fontStyle="0" />
+        <WidgetStyle name="Multi-edit carets color" styleID="0" fgColor="DC8A78" />
         <WidgetStyle name="Edge colour" styleID="0" fgColor="4C4F69" bgColor="EFF1F5" fontSize="" fontStyle="0" />
         <WidgetStyle name="Line number margin" styleID="33" fgColor="8C8FA1" bgColor="EFF1F5" fontName="" fontStyle="0" fontSize="" />
+        <WidgetStyle name="Bookmark margin" styleID="0" bgColor="EFF1F5" />
+        <WidgetStyle name="Change History margin" styleID="0" bgColor="EFF1F5" />
         <WidgetStyle name="Fold" styleID="0" fgColor="8839EF" bgColor="EFF1F5" fontStyle="0" fontSize="" />
         <WidgetStyle name="Fold active" styleID="0" fgColor="8839EF" fontStyle="0" fontSize="" bgColor="EFF1F5" />
         <WidgetStyle name="Fold margin" styleID="0" fgColor="EFF1F5" bgColor="EFF1F5" fontStyle="0" fontSize="" />
         <WidgetStyle name="White space symbol" styleID="0" fgColor="1E66F5" bgColor="EFF1F5" fontStyle="0" fontSize="" />
-        <WidgetStyle name="URL hovered" styleID="0" fgColor="04A5E5" bgColor="EFF1F5" fontStyle="0" />
-        <WidgetStyle name="Tags attribute" styleID="26" bgColor="EFF1F5" fgColor="4C4F69" fontStyle="0" />
-        <WidgetStyle name="Tags match highlighting" styleID="27" bgColor="CCCED7" fgColor="4C4F69" fontStyle="0" />
         <WidgetStyle name="Smart HighLighting" styleID="29" bgColor="7C7F93" fgColor="4C4F69" fontSize="" fontStyle="1" />
         <WidgetStyle name="Find Mark Style" styleID="31" bgColor="D20F39"></WidgetStyle>
         <WidgetStyle name="Mark Style 1" styleID="25" bgColor="209FB5"></WidgetStyle>
@@ -585,12 +586,20 @@
         <WidgetStyle name="Mark Style 3" styleID="23" bgColor="DF8E1D"></WidgetStyle>
         <WidgetStyle name="Mark Style 4" styleID="22" bgColor="8839EF"></WidgetStyle>
         <WidgetStyle name="Mark Style 5" styleID="21" bgColor="40A02B"></WidgetStyle>
-        <WidgetStyle name="Active tab focused indicator" styleID="0" fgColor="7287FD" fontStyle="0" />
+        <WidgetStyle name="Incremental highlight all" styleID="28" bgColor="1E66F5" />
+        <WidgetStyle name="Tags match highlighting" styleID="27" bgColor="CCCED7" fgColor="4C4F69" fontStyle="0" />
+        <WidgetStyle name="Tags attribute" styleID="26" bgColor="EFF1F5" fgColor="4C4F69" fontStyle="0" />
+        <WidgetStyle name="Active tab focused indicator" styleID="0" fgColor="7287FD" />
+        <WidgetStyle name="Active tab unfocused indicator" styleID="0" fgColor="209FB5" />
+        <WidgetStyle name="Active tab text" styleID="0" fgColor="7287FD" />
+        <WidgetStyle name="Inactive tabs" styleID="0" fgColor="5C5F77" bgColor="DCE0E8" />
+        <WidgetStyle name="URL hovered" styleID="0" fgColor="04A5E5" bgColor="EFF1F5" fontStyle="0" />
+        <WidgetStyle name="Document map" styleID="0" fgColor="04A5E5" bgColor="ACB0BE" />
+        <WidgetStyle name="EOL custom color" styleID="0" fgColor="6C6F85" />
+        <WidgetStyle name="Non-printing characters custom color" styleID="0" fgColor="9CA0B0" />
         <WidgetStyle name="Change History modified" styleID="0" fgColor="FE640B" bgColor="FE640B" />
         <WidgetStyle name="Change History revert modified" styleID="0" fgColor="7287FD" bgColor="7287FD" />
         <WidgetStyle name="Change History revert origin" styleID="0" fgColor="179299" bgColor="179299" />
         <WidgetStyle name="Change History saved" styleID="0" fgColor="40A02B" bgColor="40A02B" />
-        <WidgetStyle name="EOL custom color" styleID="0" fgColor="6C6F85" />
-        <WidgetStyle name="Non-printing characters custom color" styleID="0" fgColor="9CA0B0" />
     </GlobalStyles>
 </NotepadPlus>

--- a/themes/catppuccin-macchiato.xml
+++ b/themes/catppuccin-macchiato.xml
@@ -568,16 +568,17 @@
         <WidgetStyle name="Bad brace colour" styleID="35" fgColor="CAD3F5" bgColor="ED8796" fontName="" fontStyle="0" fontSize="" />
         <WidgetStyle name="Current line background colour" styleID="0" bgColor="35394D" fgColor="CAD3F5" fontSize="" fontStyle="0" />
         <WidgetStyle name="Selected text colour" styleID="0" bgColor="454A5F" fontStyle="0" />
+        <WidgetStyle name="Multi-selected text color" styleID="0" bgColor="454A5F" />
         <WidgetStyle name="Caret colour" styleID="2069" fgColor="F4DBD6" bgColor="24273A" fontStyle="0" />
+        <WidgetStyle name="Multi-edit carets color" styleID="0" fgColor="F4DBD6" />
         <WidgetStyle name="Edge colour" styleID="0" fgColor="CAD3F5" bgColor="24273A" fontSize="" fontStyle="0" />
         <WidgetStyle name="Line number margin" styleID="33" fgColor="8087A2" bgColor="24273A" fontName="" fontStyle="0" fontSize="" />
+        <WidgetStyle name="Bookmark margin" styleID="0" bgColor="24273A" />
+        <WidgetStyle name="Change History margin" styleID="0" bgColor="24273A" />
         <WidgetStyle name="Fold" styleID="0" fgColor="C6A0F6" bgColor="24273A" fontStyle="0" fontSize="" />
         <WidgetStyle name="Fold active" styleID="0" fgColor="C6A0F6" fontStyle="0" fontSize="" bgColor="24273A" />
         <WidgetStyle name="Fold margin" styleID="0" fgColor="24273A" bgColor="24273A" fontStyle="0" fontSize="" />
         <WidgetStyle name="White space symbol" styleID="0" fgColor="8AADF4" bgColor="24273A" fontStyle="0" fontSize="" />
-        <WidgetStyle name="URL hovered" styleID="0" fgColor="91D7E3" bgColor="24273A" fontStyle="0" />
-        <WidgetStyle name="Tags attribute" styleID="26" bgColor="24273A" fgColor="CAD3F5" fontStyle="0" />
-        <WidgetStyle name="Tags match highlighting" styleID="27" bgColor="454A5F" fgColor="CAD3F5" fontStyle="0" />
         <WidgetStyle name="Smart HighLighting" styleID="29" bgColor="939AB7" fgColor="CAD3F5" fontSize="" fontStyle="1" />
         <WidgetStyle name="Find Mark Style" styleID="31" bgColor="ED8796"></WidgetStyle>
         <WidgetStyle name="Mark Style 1" styleID="25" bgColor="7DC4E4"></WidgetStyle>
@@ -585,12 +586,20 @@
         <WidgetStyle name="Mark Style 3" styleID="23" bgColor="EED49F"></WidgetStyle>
         <WidgetStyle name="Mark Style 4" styleID="22" bgColor="C6A0F6"></WidgetStyle>
         <WidgetStyle name="Mark Style 5" styleID="21" bgColor="A6DA95"></WidgetStyle>
-        <WidgetStyle name="Active tab focused indicator" styleID="0" fgColor="B7BDF8" fontStyle="0" />
+        <WidgetStyle name="Incremental highlight all" styleID="28" bgColor="8AADF4" />
+        <WidgetStyle name="Tags match highlighting" styleID="27" bgColor="454A5F" fgColor="CAD3F5" fontStyle="0" />
+        <WidgetStyle name="Tags attribute" styleID="26" bgColor="24273A" fgColor="CAD3F5" fontStyle="0" />
+        <WidgetStyle name="Active tab focused indicator" styleID="0" fgColor="B7BDF8" />
+        <WidgetStyle name="Active tab unfocused indicator" styleID="0" fgColor="7DC4E4" />
+        <WidgetStyle name="Active tab text" styleID="0" fgColor="B7BDF8" />
+        <WidgetStyle name="Inactive tabs" styleID="0" fgColor="B8C0E0" bgColor="181926" />
+        <WidgetStyle name="URL hovered" styleID="0" fgColor="91D7E3" bgColor="24273A" fontStyle="0" />
+        <WidgetStyle name="Document map" styleID="0" fgColor="91D7E3" bgColor="5B6078" />
+        <WidgetStyle name="EOL custom color" styleID="0" fgColor="A5ADCB" />
+        <WidgetStyle name="Non-printing characters custom color" styleID="0" fgColor="6E738D" />
         <WidgetStyle name="Change History modified" styleID="0" fgColor="F5A97F" bgColor="F5A97F" />
         <WidgetStyle name="Change History revert modified" styleID="0" fgColor="B7BDF8" bgColor="B7BDF8" />
         <WidgetStyle name="Change History revert origin" styleID="0" fgColor="8BD5CA" bgColor="8BD5CA" />
         <WidgetStyle name="Change History saved" styleID="0" fgColor="A6DA95" bgColor="A6DA95" />
-        <WidgetStyle name="EOL custom color" styleID="0" fgColor="A5ADCB" />
-        <WidgetStyle name="Non-printing characters custom color" styleID="0" fgColor="6E738D" />
     </GlobalStyles>
 </NotepadPlus>

--- a/themes/catppuccin-macchiato.xml
+++ b/themes/catppuccin-macchiato.xml
@@ -560,46 +560,60 @@
         </LexerType>
     </LexerStyles>
     <GlobalStyles>
-        <!-- Attention : Don't modify the name of styleID="0" -->
-        <WidgetStyle name="Global override" styleID="0" fgColor="CAD3F5" bgColor="24273A" fontName="Consolas" fontStyle="0" fontSize="10" />
+        <!-- Attention : Don't modify the name of any styleID="0" -->
         <WidgetStyle name="Default Style" styleID="32" fgColor="CAD3F5" bgColor="24273A" fontName="Consolas" fontStyle="0" fontSize="10" />
         <WidgetStyle name="Indent guideline style" styleID="37" fgColor="8AADF4" bgColor="24273A" fontName="" fontStyle="0" fontSize="" />
         <WidgetStyle name="Brace highlight style" styleID="34" fgColor="CAD3F5" bgColor="454A5F" fontName="" fontStyle="1" fontSize="10" />
-        <WidgetStyle name="Bad brace colour" styleID="35" fgColor="CAD3F5" bgColor="ED8796" fontName="" fontStyle="0" fontSize="" />
-        <WidgetStyle name="Current line background colour" styleID="0" bgColor="35394D" fgColor="CAD3F5" fontSize="" fontStyle="0" />
+        <WidgetStyle name="Bad brace colour" styleID="35" fgColor="181926" bgColor="ED8796" fontName="" fontStyle="0" fontSize="" />
+        <WidgetStyle name="Current line background colour" styleID="0" bgColor="35394D" fgColor="CAD3F5" fontSize="" fontStyle="" />
+        <!-- In below rule 'fgColor' attribute for 'Selected text colour' can be unlocked with a enableSelectFgColor.xml file -->
         <WidgetStyle name="Selected text colour" styleID="0" bgColor="454A5F" fontStyle="0" />
         <WidgetStyle name="Multi-selected text color" styleID="0" bgColor="454A5F" />
-        <WidgetStyle name="Caret colour" styleID="2069" fgColor="F4DBD6" bgColor="24273A" fontStyle="0" />
+        <WidgetStyle name="Caret colour" styleID="2069" fgColor="F4DBD6" />
         <WidgetStyle name="Multi-edit carets color" styleID="0" fgColor="F4DBD6" />
-        <WidgetStyle name="Edge colour" styleID="0" fgColor="CAD3F5" bgColor="24273A" fontSize="" fontStyle="0" />
+        <WidgetStyle name="Edge colour" styleID="0" fgColor="CAD3F5" />
         <WidgetStyle name="Line number margin" styleID="33" fgColor="8087A2" bgColor="24273A" fontName="" fontStyle="0" fontSize="" />
         <WidgetStyle name="Bookmark margin" styleID="0" bgColor="24273A" />
         <WidgetStyle name="Change History margin" styleID="0" bgColor="24273A" />
-        <WidgetStyle name="Fold" styleID="0" fgColor="C6A0F6" bgColor="24273A" fontStyle="0" fontSize="" />
-        <WidgetStyle name="Fold active" styleID="0" fgColor="C6A0F6" fontStyle="0" fontSize="" bgColor="24273A" />
-        <WidgetStyle name="Fold margin" styleID="0" fgColor="24273A" bgColor="24273A" fontStyle="0" fontSize="" />
-        <WidgetStyle name="White space symbol" styleID="0" fgColor="8AADF4" bgColor="24273A" fontStyle="0" fontSize="" />
-        <WidgetStyle name="Smart HighLighting" styleID="29" bgColor="939AB7" fgColor="CAD3F5" fontSize="" fontStyle="1" />
-        <WidgetStyle name="Find Mark Style" styleID="31" bgColor="ED8796"></WidgetStyle>
-        <WidgetStyle name="Mark Style 1" styleID="25" bgColor="7DC4E4"></WidgetStyle>
-        <WidgetStyle name="Mark Style 2" styleID="24" bgColor="F5A97F"></WidgetStyle>
-        <WidgetStyle name="Mark Style 3" styleID="23" bgColor="EED49F"></WidgetStyle>
-        <WidgetStyle name="Mark Style 4" styleID="22" bgColor="C6A0F6"></WidgetStyle>
-        <WidgetStyle name="Mark Style 5" styleID="21" bgColor="A6DA95"></WidgetStyle>
-        <WidgetStyle name="Incremental highlight all" styleID="28" bgColor="8AADF4" />
-        <WidgetStyle name="Tags match highlighting" styleID="27" bgColor="454A5F" fgColor="CAD3F5" fontStyle="0" />
-        <WidgetStyle name="Tags attribute" styleID="26" bgColor="24273A" fgColor="CAD3F5" fontStyle="0" />
-        <WidgetStyle name="Active tab focused indicator" styleID="0" fgColor="B7BDF8" />
-        <WidgetStyle name="Active tab unfocused indicator" styleID="0" fgColor="7DC4E4" />
-        <WidgetStyle name="Active tab text" styleID="0" fgColor="B7BDF8" />
-        <WidgetStyle name="Inactive tabs" styleID="0" fgColor="B8C0E0" bgColor="181926" />
-        <WidgetStyle name="URL hovered" styleID="0" fgColor="91D7E3" bgColor="24273A" fontStyle="0" />
-        <WidgetStyle name="Document map" styleID="0" fgColor="91D7E3" bgColor="5B6078" />
-        <WidgetStyle name="EOL custom color" styleID="0" fgColor="A5ADCB" />
-        <WidgetStyle name="Non-printing characters custom color" styleID="0" fgColor="6E738D" />
         <WidgetStyle name="Change History modified" styleID="0" fgColor="F5A97F" bgColor="F5A97F" />
         <WidgetStyle name="Change History revert modified" styleID="0" fgColor="B7BDF8" bgColor="B7BDF8" />
         <WidgetStyle name="Change History revert origin" styleID="0" fgColor="8BD5CA" bgColor="8BD5CA" />
         <WidgetStyle name="Change History saved" styleID="0" fgColor="A6DA95" bgColor="A6DA95" />
+        <WidgetStyle name="Fold" styleID="0" fgColor="C6A0F6" bgColor="24273A" />
+        <WidgetStyle name="Fold active" styleID="0" fgColor="C6A0F6" />
+        <WidgetStyle name="Fold margin" styleID="0" fgColor="24273A" bgColor="24273A" />
+        <WidgetStyle name="White space symbol" styleID="0" fgColor="939AB7" bgColor="24273A" fontstyle="0" fontSize="" />
+        <WidgetStyle name="Smart Highlighting" styleID="29" bgColor="6E738D" />
+        <WidgetStyle name="Find Mark Style" styleID="31" bgColor="EE99A0" />
+        <WidgetStyle name="Find status: Not found" styleID="0" fgColor="ED8796" />
+        <WidgetStyle name="Find status: Message" styleID="0" fgColor="8BD5CA" />
+        <WidgetStyle name="Find status: Search end reached" styleID="0" fgColor="EED49F" />
+        <WidgetStyle name="Mark Style 1" styleID="25" bgColor="7DC4E4" />
+        <WidgetStyle name="Mark Style 2" styleID="24" bgColor="EE99A0" />
+        <WidgetStyle name="Mark Style 3" styleID="23" bgColor="EED49F" />
+        <WidgetStyle name="Mark Style 4" styleID="22" bgColor="C6A0F6" />
+        <WidgetStyle name="Mark Style 5" styleID="21" bgColor="A6DA95" />
+        <WidgetStyle name="Incremental highlight all" styleID="28" bgColor="8AADF4" />
+        <WidgetStyle name="Tags match highlighting" styleID="27" bgColor="454A5F" />
+        <WidgetStyle name="Tags attribute" styleID="26" bgColor="24273A" />
+        <WidgetStyle name="Active tab focused indicator" styleID="0" fgColor="B7BDF8" />
+        <WidgetStyle name="Active tab unfocused indicator" styleID="0" fgColor="8087A2" />
+        <WidgetStyle name="Active tab text" styleID="0" fgColor="CAD3F5" />
+        <WidgetStyle name="Inactive tabs" styleID="0" fgColor="B8C0E0" bgColor="181926" />
+        <WidgetStyle name="Tab color 1" styleID="0" bgColor="F5A97F" />
+        <WidgetStyle name="Tab color 2" styleID="0" bgColor="A6DA95" />
+        <WidgetStyle name="Tab color 3" styleID="0" bgColor="F5BDE6" />
+        <WidgetStyle name="Tab color 4" styleID="0" bgColor="8AADF4" />
+        <WidgetStyle name="Tab color 5" styleID="0" bgColor="ED8796" />
+        <WidgetStyle name="Tab color dark mode 1" styleID="0" bgColor="F5A97F" />
+        <WidgetStyle name="Tab color dark mode 2" styleID="0" bgColor="A6DA95" />
+        <WidgetStyle name="Tab color dark mode 3" styleID="0" bgColor="F5BDE6" />
+        <WidgetStyle name="Tab color dark mode 4" styleID="0" bgColor="8AADF4" />
+        <WidgetStyle name="Tab color dark mode 5" styleID="0" bgColor="ED8796" />
+        <WidgetStyle name="URL hovered" styleID="0" fgColor="91D7E3" bgColor="24273A" fontStyle="0" />
+        <WidgetStyle name="Document map" styleID="0" fgColor="91D7E3" bgColor="5B6078" />
+        <WidgetStyle name="EOL custom color" styleID="0" fgColor="A5ADCB" />
+        <WidgetStyle name="Non-printing characters custom color" styleID="0" fgColor="6E738D" />
+        <WidgetStyle name="Global override" styleID="0" fgColor="CAD3F5" bgColor="24273A" fontName="" fontStyle="0" fontSize="10" />
     </GlobalStyles>
 </NotepadPlus>

--- a/themes/catppuccin-mocha.xml
+++ b/themes/catppuccin-mocha.xml
@@ -568,16 +568,17 @@
         <WidgetStyle name="Bad brace colour" styleID="35" fgColor="CDD6F4" bgColor="F38BA8" fontName="" fontStyle="0" fontSize="" />
         <WidgetStyle name="Current line background colour" styleID="0" bgColor="303142" fgColor="CDD6F4" fontSize="" fontStyle="0" />
         <WidgetStyle name="Selected text colour" styleID="0" bgColor="414356" fontStyle="0" />
+        <WidgetStyle name="Multi-selected text color" styleID="0" bgColor="414356" />
         <WidgetStyle name="Caret colour" styleID="2069" fgColor="F5E0DC" bgColor="1E1E2E" fontStyle="0" />
+        <WidgetStyle name="Multi-edit carets color" styleID="0" fgColor="F5E0DC" />
         <WidgetStyle name="Edge colour" styleID="0" fgColor="CDD6F4" bgColor="1E1E2E" fontSize="" fontStyle="0" />
         <WidgetStyle name="Line number margin" styleID="33" fgColor="7F849C" bgColor="1E1E2E" fontName="" fontStyle="0" fontSize="" />
+        <WidgetStyle name="Bookmark margin" styleID="0" bgColor="1E1E2E" />
+        <WidgetStyle name="Change History margin" styleID="0" bgColor="1E1E2E" />
         <WidgetStyle name="Fold" styleID="0" fgColor="CBA6F7" bgColor="1E1E2E" fontStyle="0" fontSize="" />
         <WidgetStyle name="Fold active" styleID="0" fgColor="CBA6F7" fontStyle="0" fontSize="" bgColor="1E1E2E" />
         <WidgetStyle name="Fold margin" styleID="0" fgColor="1E1E2E" bgColor="1E1E2E" fontStyle="0" fontSize="" />
         <WidgetStyle name="White space symbol" styleID="0" fgColor="89B4FA" bgColor="1E1E2E" fontStyle="0" fontSize="" />
-        <WidgetStyle name="URL hovered" styleID="0" fgColor="89DCEB" bgColor="1E1E2E" fontStyle="0" />
-        <WidgetStyle name="Tags attribute" styleID="26" bgColor="1E1E2E" fgColor="CDD6F4" fontStyle="0" />
-        <WidgetStyle name="Tags match highlighting" styleID="27" bgColor="414356" fgColor="CDD6F4" fontStyle="0" />
         <WidgetStyle name="Smart HighLighting" styleID="29" bgColor="9399B2" fgColor="CDD6F4" fontSize="" fontStyle="1" />
         <WidgetStyle name="Find Mark Style" styleID="31" bgColor="F38BA8"></WidgetStyle>
         <WidgetStyle name="Mark Style 1" styleID="25" bgColor="74C7EC"></WidgetStyle>
@@ -585,12 +586,20 @@
         <WidgetStyle name="Mark Style 3" styleID="23" bgColor="F9E2AF"></WidgetStyle>
         <WidgetStyle name="Mark Style 4" styleID="22" bgColor="CBA6F7"></WidgetStyle>
         <WidgetStyle name="Mark Style 5" styleID="21" bgColor="A6E3A1"></WidgetStyle>
-        <WidgetStyle name="Active tab focused indicator" styleID="0" fgColor="B4BEFE" fontStyle="0" />
+        <WidgetStyle name="Incremental highlight all" styleID="28" bgColor="89B4FA" />
+        <WidgetStyle name="Tags match highlighting" styleID="27" bgColor="414356" fgColor="CDD6F4" fontStyle="0" />
+        <WidgetStyle name="Tags attribute" styleID="26" bgColor="1E1E2E" fgColor="CDD6F4" fontStyle="0" />
+        <WidgetStyle name="Active tab focused indicator" styleID="0" fgColor="B4BEFE" />
+        <WidgetStyle name="Active tab unfocused indicator" styleID="0" fgColor="74C7EC" />
+        <WidgetStyle name="Active tab text" styleID="0" fgColor="B4BEFE" />
+        <WidgetStyle name="Inactive tabs" styleID="0" fgColor="BAC2DE" bgColor="11111B" />
+        <WidgetStyle name="URL hovered" styleID="0" fgColor="89DCEB" bgColor="1E1E2E" fontStyle="0" />
+        <WidgetStyle name="Document map" styleID="0" fgColor="89DCEB" bgColor="585B70" />
+        <WidgetStyle name="EOL custom color" styleID="0" fgColor="A6ADC8" />
+        <WidgetStyle name="Non-printing characters custom color" styleID="0" fgColor="6C7086" />
         <WidgetStyle name="Change History modified" styleID="0" fgColor="FAB387" bgColor="FAB387" />
         <WidgetStyle name="Change History revert modified" styleID="0" fgColor="B4BEFE" bgColor="B4BEFE" />
         <WidgetStyle name="Change History revert origin" styleID="0" fgColor="94E2D5" bgColor="94E2D5" />
         <WidgetStyle name="Change History saved" styleID="0" fgColor="A6E3A1" bgColor="A6E3A1" />
-        <WidgetStyle name="EOL custom color" styleID="0" fgColor="A6ADC8" />
-        <WidgetStyle name="Non-printing characters custom color" styleID="0" fgColor="6C7086" />
     </GlobalStyles>
 </NotepadPlus>

--- a/themes/catppuccin-mocha.xml
+++ b/themes/catppuccin-mocha.xml
@@ -560,46 +560,60 @@
         </LexerType>
     </LexerStyles>
     <GlobalStyles>
-        <!-- Attention : Don't modify the name of styleID="0" -->
-        <WidgetStyle name="Global override" styleID="0" fgColor="CDD6F4" bgColor="1E1E2E" fontName="Consolas" fontStyle="0" fontSize="10" />
+        <!-- Attention : Don't modify the name of any styleID="0" -->
         <WidgetStyle name="Default Style" styleID="32" fgColor="CDD6F4" bgColor="1E1E2E" fontName="Consolas" fontStyle="0" fontSize="10" />
         <WidgetStyle name="Indent guideline style" styleID="37" fgColor="89B4FA" bgColor="1E1E2E" fontName="" fontStyle="0" fontSize="" />
         <WidgetStyle name="Brace highlight style" styleID="34" fgColor="CDD6F4" bgColor="414356" fontName="" fontStyle="1" fontSize="10" />
-        <WidgetStyle name="Bad brace colour" styleID="35" fgColor="CDD6F4" bgColor="F38BA8" fontName="" fontStyle="0" fontSize="" />
-        <WidgetStyle name="Current line background colour" styleID="0" bgColor="303142" fgColor="CDD6F4" fontSize="" fontStyle="0" />
+        <WidgetStyle name="Bad brace colour" styleID="35" fgColor="11111B" bgColor="F38BA8" fontName="" fontStyle="0" fontSize="" />
+        <WidgetStyle name="Current line background colour" styleID="0" bgColor="303142" fgColor="CDD6F4" fontSize="" fontStyle="" />
+        <!-- In below rule 'fgColor' attribute for 'Selected text colour' can be unlocked with a enableSelectFgColor.xml file -->
         <WidgetStyle name="Selected text colour" styleID="0" bgColor="414356" fontStyle="0" />
         <WidgetStyle name="Multi-selected text color" styleID="0" bgColor="414356" />
-        <WidgetStyle name="Caret colour" styleID="2069" fgColor="F5E0DC" bgColor="1E1E2E" fontStyle="0" />
+        <WidgetStyle name="Caret colour" styleID="2069" fgColor="F5E0DC" />
         <WidgetStyle name="Multi-edit carets color" styleID="0" fgColor="F5E0DC" />
-        <WidgetStyle name="Edge colour" styleID="0" fgColor="CDD6F4" bgColor="1E1E2E" fontSize="" fontStyle="0" />
+        <WidgetStyle name="Edge colour" styleID="0" fgColor="CDD6F4" />
         <WidgetStyle name="Line number margin" styleID="33" fgColor="7F849C" bgColor="1E1E2E" fontName="" fontStyle="0" fontSize="" />
         <WidgetStyle name="Bookmark margin" styleID="0" bgColor="1E1E2E" />
         <WidgetStyle name="Change History margin" styleID="0" bgColor="1E1E2E" />
-        <WidgetStyle name="Fold" styleID="0" fgColor="CBA6F7" bgColor="1E1E2E" fontStyle="0" fontSize="" />
-        <WidgetStyle name="Fold active" styleID="0" fgColor="CBA6F7" fontStyle="0" fontSize="" bgColor="1E1E2E" />
-        <WidgetStyle name="Fold margin" styleID="0" fgColor="1E1E2E" bgColor="1E1E2E" fontStyle="0" fontSize="" />
-        <WidgetStyle name="White space symbol" styleID="0" fgColor="89B4FA" bgColor="1E1E2E" fontStyle="0" fontSize="" />
-        <WidgetStyle name="Smart HighLighting" styleID="29" bgColor="9399B2" fgColor="CDD6F4" fontSize="" fontStyle="1" />
-        <WidgetStyle name="Find Mark Style" styleID="31" bgColor="F38BA8"></WidgetStyle>
-        <WidgetStyle name="Mark Style 1" styleID="25" bgColor="74C7EC"></WidgetStyle>
-        <WidgetStyle name="Mark Style 2" styleID="24" bgColor="FAB387"></WidgetStyle>
-        <WidgetStyle name="Mark Style 3" styleID="23" bgColor="F9E2AF"></WidgetStyle>
-        <WidgetStyle name="Mark Style 4" styleID="22" bgColor="CBA6F7"></WidgetStyle>
-        <WidgetStyle name="Mark Style 5" styleID="21" bgColor="A6E3A1"></WidgetStyle>
-        <WidgetStyle name="Incremental highlight all" styleID="28" bgColor="89B4FA" />
-        <WidgetStyle name="Tags match highlighting" styleID="27" bgColor="414356" fgColor="CDD6F4" fontStyle="0" />
-        <WidgetStyle name="Tags attribute" styleID="26" bgColor="1E1E2E" fgColor="CDD6F4" fontStyle="0" />
-        <WidgetStyle name="Active tab focused indicator" styleID="0" fgColor="B4BEFE" />
-        <WidgetStyle name="Active tab unfocused indicator" styleID="0" fgColor="74C7EC" />
-        <WidgetStyle name="Active tab text" styleID="0" fgColor="B4BEFE" />
-        <WidgetStyle name="Inactive tabs" styleID="0" fgColor="BAC2DE" bgColor="11111B" />
-        <WidgetStyle name="URL hovered" styleID="0" fgColor="89DCEB" bgColor="1E1E2E" fontStyle="0" />
-        <WidgetStyle name="Document map" styleID="0" fgColor="89DCEB" bgColor="585B70" />
-        <WidgetStyle name="EOL custom color" styleID="0" fgColor="A6ADC8" />
-        <WidgetStyle name="Non-printing characters custom color" styleID="0" fgColor="6C7086" />
         <WidgetStyle name="Change History modified" styleID="0" fgColor="FAB387" bgColor="FAB387" />
         <WidgetStyle name="Change History revert modified" styleID="0" fgColor="B4BEFE" bgColor="B4BEFE" />
         <WidgetStyle name="Change History revert origin" styleID="0" fgColor="94E2D5" bgColor="94E2D5" />
         <WidgetStyle name="Change History saved" styleID="0" fgColor="A6E3A1" bgColor="A6E3A1" />
+        <WidgetStyle name="Fold" styleID="0" fgColor="CBA6F7" bgColor="1E1E2E" />
+        <WidgetStyle name="Fold active" styleID="0" fgColor="CBA6F7" />
+        <WidgetStyle name="Fold margin" styleID="0" fgColor="1E1E2E" bgColor="1E1E2E" />
+        <WidgetStyle name="White space symbol" styleID="0" fgColor="9399B2" bgColor="1E1E2E" fontstyle="0" fontSize="" />
+        <WidgetStyle name="Smart Highlighting" styleID="29" bgColor="6C7086" />
+        <WidgetStyle name="Find Mark Style" styleID="31" bgColor="EBA0AC" />
+        <WidgetStyle name="Find status: Not found" styleID="0" fgColor="F38BA8" />
+        <WidgetStyle name="Find status: Message" styleID="0" fgColor="94E2D5" />
+        <WidgetStyle name="Find status: Search end reached" styleID="0" fgColor="F9E2AF" />
+        <WidgetStyle name="Mark Style 1" styleID="25" bgColor="74C7EC" />
+        <WidgetStyle name="Mark Style 2" styleID="24" bgColor="EBA0AC" />
+        <WidgetStyle name="Mark Style 3" styleID="23" bgColor="F9E2AF" />
+        <WidgetStyle name="Mark Style 4" styleID="22" bgColor="CBA6F7" />
+        <WidgetStyle name="Mark Style 5" styleID="21" bgColor="A6E3A1" />
+        <WidgetStyle name="Incremental highlight all" styleID="28" bgColor="89B4FA" />
+        <WidgetStyle name="Tags match highlighting" styleID="27" bgColor="414356" />
+        <WidgetStyle name="Tags attribute" styleID="26" bgColor="1E1E2E" />
+        <WidgetStyle name="Active tab focused indicator" styleID="0" fgColor="B4BEFE" />
+        <WidgetStyle name="Active tab unfocused indicator" styleID="0" fgColor="7F849C" />
+        <WidgetStyle name="Active tab text" styleID="0" fgColor="CDD6F4" />
+        <WidgetStyle name="Inactive tabs" styleID="0" fgColor="BAC2DE" bgColor="11111B" />
+        <WidgetStyle name="Tab color 1" styleID="0" bgColor="FAB387" />
+        <WidgetStyle name="Tab color 2" styleID="0" bgColor="A6E3A1" />
+        <WidgetStyle name="Tab color 3" styleID="0" bgColor="F5C2E7" />
+        <WidgetStyle name="Tab color 4" styleID="0" bgColor="89B4FA" />
+        <WidgetStyle name="Tab color 5" styleID="0" bgColor="F38BA8" />
+        <WidgetStyle name="Tab color dark mode 1" styleID="0" bgColor="FAB387" />
+        <WidgetStyle name="Tab color dark mode 2" styleID="0" bgColor="A6E3A1" />
+        <WidgetStyle name="Tab color dark mode 3" styleID="0" bgColor="F5C2E7" />
+        <WidgetStyle name="Tab color dark mode 4" styleID="0" bgColor="89B4FA" />
+        <WidgetStyle name="Tab color dark mode 5" styleID="0" bgColor="F38BA8" />
+        <WidgetStyle name="URL hovered" styleID="0" fgColor="89DCEB" bgColor="1E1E2E" fontStyle="0" />
+        <WidgetStyle name="Document map" styleID="0" fgColor="89DCEB" bgColor="585B70" />
+        <WidgetStyle name="EOL custom color" styleID="0" fgColor="A6ADC8" />
+        <WidgetStyle name="Non-printing characters custom color" styleID="0" fgColor="6C7086" />
+        <WidgetStyle name="Global override" styleID="0" fgColor="CDD6F4" bgColor="1E1E2E" fontName="" fontStyle="0" fontSize="10" />
     </GlobalStyles>
 </NotepadPlus>

--- a/ui-theme.md
+++ b/ui-theme.md
@@ -1,5 +1,5 @@
-
 # Changing UI Colors
+
 Notepad++ has limited support for customizing the UI elements.
 Some elements are controlled by the Windows theme (menu dropdowns, scrollbars, etc.) and can't be changed.
 
@@ -13,7 +13,7 @@ Replace the line beginning with `<GUIConfig name="DarkMode">` with the desired f
 <summary>🌻 Latte</summary>
 
 ```xml
-<GUIConfig name="DarkMode" enable="yes" colorTone="32" customColorTop="16118255" customColorMenuHotTrack="13418684" customColorActive="15722982" customColorMain="15261916" customColorError="3739602" customColorText="6901580" customColorDarkText="7823196" customColorDisabledText="8744812" customColorLinkText="16082462" customColorEdge="10588044" customColorHotEdge="9666428" customColorDisabledEdge="11575452" enableWindowsMode="no" darkThemeName="catppuccin-latte.xml" darkToolBarIconSet="2" darkTabIconSet="2" darkTabUseTheme="no" lightThemeName="catppuccin-latte.xml" lightToolBarIconSet="4" lightTabIconSet="0" lightTabUseTheme="yes" />
+<GUIConfig name="DarkMode" enable="yes" colorTone="32" customColorTop="16118255" customColorMenuHotTrack="13418684" customColorActive="15722982" customColorMain="15261916" customColorError="3739602" customColorText="6901580" customColorDarkText="7823196" customColorDisabledText="8744812" customColorLinkText="16082462" customColorEdge="10588044" customColorHotEdge="9666428" customColorDisabledEdge="11575452" enableWindowsMode="no" darkThemeName="catppuccin-latte.xml" darkToolBarIconSet="2" darkTabIconSet="2" darkTabUseTheme="yes" lightThemeName="catppuccin-latte.xml" lightToolBarIconSet="4" lightTabIconSet="0" lightTabUseTheme="yes" />
 ```
 
 </details>
@@ -21,7 +21,7 @@ Replace the line beginning with `<GUIConfig name="DarkMode">` with the desired f
 <summary>🪴 Frappé</summary>
 
 ```xml
-<GUIConfig name="DarkMode" enable="yes" colorTone="32" customColorTop="4600880" customColorMenuHotTrack="7165777" customColorActive="3943465" customColorMain="3417635" customColorError="8684263" customColorText="16109766" customColorDarkText="14860213" customColorDisabledText="13544869" customColorLinkText="15641228" customColorEdge="10980227" customColorHotEdge="12295316" customColorDisabledEdge="9730419" enableWindowsMode="no" darkThemeName="catppuccin-frappe.xml" darkToolBarIconSet="2" darkTabIconSet="2" darkTabUseTheme="no" lightThemeName="catppuccin-frappe.xml" lightToolBarIconSet="4" lightTabIconSet="0" lightTabUseTheme="yes" />
+<GUIConfig name="DarkMode" enable="yes" colorTone="32" customColorTop="4600880" customColorMenuHotTrack="7165777" customColorActive="3943465" customColorMain="3417635" customColorError="8684263" customColorText="16109766" customColorDarkText="14860213" customColorDisabledText="13544869" customColorLinkText="15641228" customColorEdge="10980227" customColorHotEdge="12295316" customColorDisabledEdge="9730419" enableWindowsMode="no" darkThemeName="catppuccin-frappe.xml" darkToolBarIconSet="2" darkTabIconSet="2" darkTabUseTheme="yes" lightThemeName="catppuccin-frappe.xml" lightToolBarIconSet="4" lightTabIconSet="0" lightTabUseTheme="yes" />
 ```
 
 </details>
@@ -29,7 +29,7 @@ Replace the line beginning with `<GUIConfig name="DarkMode">` with the desired f
 <summary>🌺 Macchiato</summary>
 
 ```xml
-<GUIConfig name="DarkMode" enable="yes" colorTone="32" customColorTop="3811108" customColorMenuHotTrack="6573385" customColorActive="3153950" customColorMain="2496792" customColorError="9865197" customColorText="16110538" customColorDarkText="14729400" customColorDisabledText="13348261" customColorLinkText="16035210" customColorEdge="10651520" customColorHotEdge="12032659" customColorDisabledEdge="9270126" enableWindowsMode="no" darkThemeName="catppuccin-macchiato.xml" darkToolBarIconSet="2" darkTabIconSet="2" darkTabUseTheme="no" lightThemeName="catppuccin-macchiato.xml" lightToolBarIconSet="4" lightTabIconSet="0" lightTabUseTheme="yes" />
+<GUIConfig name="DarkMode" enable="yes" colorTone="32" customColorTop="3811108" customColorMenuHotTrack="6573385" customColorActive="3153950" customColorMain="2496792" customColorError="9865197" customColorText="16110538" customColorDarkText="14729400" customColorDisabledText="13348261" customColorLinkText="16035210" customColorEdge="10651520" customColorHotEdge="12032659" customColorDisabledEdge="9270126" enableWindowsMode="no" darkThemeName="catppuccin-macchiato.xml" darkToolBarIconSet="2" darkTabIconSet="2" darkTabUseTheme="yes" lightThemeName="catppuccin-macchiato.xml" lightToolBarIconSet="4" lightTabIconSet="0" lightTabUseTheme="yes" />
 ```
 
 </details>
@@ -37,7 +37,7 @@ Replace the line beginning with `<GUIConfig name="DarkMode">` with the desired f
 <summary>🌿 Mocha</summary>
 
 ```xml
-<GUIConfig name="DarkMode" enable="yes" colorTone="32" customColorTop="3022366" customColorMenuHotTrack="5916485" customColorActive="2431000" customColorMain="1773841" customColorError="11045875" customColorText="16045773" customColorDarkText="14598842" customColorDisabledText="13151654" customColorLinkText="16430217" customColorEdge="10257535" customColorHotEdge="11704723" customColorDisabledEdge="8810604" enableWindowsMode="no" darkThemeName="catppuccin-mocha.xml" darkToolBarIconSet="2" darkTabIconSet="2" darkTabUseTheme="no" lightThemeName="catppuccin-mocha.xml" lightToolBarIconSet="4" lightTabIconSet="0" lightTabUseTheme="yes" />
+<GUIConfig name="DarkMode" enable="yes" colorTone="32" customColorTop="3022366" customColorMenuHotTrack="5916485" customColorActive="2431000" customColorMain="1773841" customColorError="11045875" customColorText="16045773" customColorDarkText="14598842" customColorDisabledText="13151654" customColorLinkText="16430217" customColorEdge="10257535" customColorHotEdge="11704723" customColorDisabledEdge="8810604" enableWindowsMode="no" darkThemeName="catppuccin-mocha.xml" darkToolBarIconSet="2" darkTabIconSet="2" darkTabUseTheme="yes" lightThemeName="catppuccin-mocha.xml" lightToolBarIconSet="4" lightTabIconSet="0" lightTabUseTheme="yes" />
 ```
 
 </details>


### PR DESCRIPTION
Adds all the style groups to match the default (stylers.xml) available in the most recent version of Npp (v8.7.7).

I have also re-ordered the list to match the default style for clarity.

Includes these groups:
- Multi-selected text color (30% overlay2, 70% base)
- Multi-edit carets [cursor] color (rosewater)
- Bookmark margin (base)
- Change History Margin (base)
- Fold Margin (base)
- Incremental highlight all ( Search > Incremental Search [Ctrl+Alt+I] ) (blue)
- Active tab unfoced indicator (I can't identify what this actually changes) 
- Active tab text fg color text
- Inactive tabs (foreground and background) (subtext, crust)
- Document map (view > document map) ( surface2 )

- Orders the keys to match built-in theme (effects order in UI as well)

- Adds a couple missing styles (Find status messages)

- Change bad brace error foreground to crust (on red bg)

- Change white space symbol fg (tab/SPACE) to overlay2

- Adds "Tab color" groups (right click on a tab). These are meant to be
visual color sorting. The implementation is somewhat flawed because
there is no way to change the foreground text for better contrast,
afaik.

Visually, this addition affects very little, and all of these groups have clear color assignments.

In order for tab styles to work, I enabled the attribute "darkTabUseTheme" in the config.xml modification. There does not seem to be a way to set the active tab background color in the theme, it will use the "Active" custom UI color (currently `mantle`)