### PR TITLE
chore: add linguist-language attribute for tera templates

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 themes/* linguist-generated=true
+templates/**.tera linguist-language=xml
 ui-theme.md linguist-generated=true


### PR DESCRIPTION
This will allow syntax highlighting for template files on Github.com

It may also affect the language distribution chart for the repository, once the server runs analysis and updates the display.
