### PR TITLE
ci(check): update setup-whiskers

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,6 +1,7 @@
-name: Whiskers Check
+name: whiskers
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
   pull_request:
@@ -11,9 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: catppuccin/setup-whiskers@v1
-        with:
-          whiskers-version: 2.5.1
+      - uses: catppuccin/setup-whiskers@v2
       - run: |
           whiskers templates/editor.tera --check
           whiskers templates/ui.tera --check ui-theme.md

--- a/templates/editor.tera
+++ b/templates/editor.tera
@@ -1,6 +1,6 @@
 ---
 whiskers:
-  version: 2.5.1
+  version: ^2.5.1
   matrix:
     - flavor
   filename: "themes/catppuccin-{{ flavor.identifier }}.xml"

--- a/templates/ui.tera
+++ b/templates/ui.tera
@@ -1,6 +1,6 @@
 ---
 whiskers:
-  version: 2.5.1
+  version: ^2.5.1
   filename: "ui-theme.md"
 ---
 {%- macro bgr(c) -%}


### PR DESCRIPTION
We can't fully use the reusable workflow yet but at least we can stop hard-coding the version now :+1: 