### PR TITLE
feat: support toolbar icon accent color

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@
 1. Download your preferred flavor(s) from [`themes/`](./themes/).
 2. Move downloaded flavor(s) to NotePad++ theme directory (default: `%AppData%\Notepad++\themes`).
 3. To customize the UI colors (non-editor area), follow the instructions for your flavor on this page: [`ui-theme.md`](./ui-theme.md)
-4. Select the desired theme in Settings > Style Configurator
-5. Modify the Global Styles > Default Style to pick a font name and adjust default font size to your liking
+4. Select the desired editor theme in Settings > Style Configurator
+5. Modify the Global Styles > Default Style to pick a typeface and adjust default font size to your liking
 
 ## 💝 Thanks to
 

--- a/templates/ui.tera
+++ b/templates/ui.tera
@@ -11,10 +11,25 @@ whiskers:
 Notepad++ has limited support for customizing the UI elements.
 Some elements are controlled by the Windows theme (menu dropdowns, scrollbars, etc.) and can't be changed.
 
-You can theme the supported elements by modifying a line in the file `%AppData%/Notepad++/config.xml`.
-Replace the line beginning with `<GUIConfig name="DarkMode">` with the desired flavor.
+Some aspects of the color theme can optionally be enabled in the UI settings dialog:
+- Preferences > Editing 1
+  - Apply custom color to selected text foreground
+- Preferences > Editing 2
+  - EOL (CRLF) > Custom Color
+  - Non-Printing Characters > Appearance > Custom Color
+  - Non-Printing Characters > Apply Appearance to C0, C1, EOL
+- Preferences > Toolbar > Pick an icon theme
+  - Pick "Complete" or "Partial" Colorization
+  - Color choice > Custom
+- Preferences > Margins/Border/Edge > Pick what you like
 
-> [!NOTE]
+You can theme the UI elements by modifying a line in the config file (Default: `%AppData%/Notepad++/config.xml`)
+
+Replace the line beginning with `<GUIConfig name="DarkMode" ...>` with the desired flavor.
+
+Some options may not be available in older versions of Notepad++. If you recently updated, add this line to the config again, as older versions will delete unused properties.
+
+> [!WARNING]
 > You cannot use Notepad++ to make this change, as it will overwrite any changes to `config.xml` when closing.
 
 {% for id, flavor in flavors -%}
@@ -23,7 +38,7 @@ Replace the line beginning with `<GUIConfig name="DarkMode">` with the desired f
 <summary>{{ flavor.emoji }} {{ flavor.name }}</summary>
 
 ```xml
-<GUIConfig name="DarkMode" enable="yes" colorTone="32" customColorTop="{{ self::bgr(c=l.base) }}" customColorMenuHotTrack="{{ self::bgr(c=l.surface1) }}" customColorActive="{{ self::bgr(c=l.mantle) }}" customColorMain="{{ self::bgr(c=l.crust) }}" customColorError="{{ self::bgr(c=l.red) }}" customColorText="{{ self::bgr(c=l.text) }}" customColorDarkText="{{ self::bgr(c=l.subtext1) }}" customColorDisabledText="{{ self::bgr(c=l.subtext0) }}" customColorLinkText="{{ self::bgr(c=l.blue)}}" customColorEdge="{{ self::bgr(c=l.overlay1) }}" customColorHotEdge="{{ self::bgr(c=l.overlay2) }}" customColorDisabledEdge="{{ self::bgr(c=l.overlay0) }}" enableWindowsMode="no" darkThemeName="catppuccin-{{ flavor.identifier }}.xml" darkToolBarIconSet="2" darkTabIconSet="2" darkTabUseTheme="yes" lightThemeName="catppuccin-{{ flavor.identifier }}.xml" lightToolBarIconSet="4" lightTabIconSet="0" lightTabUseTheme="yes" />
+<GUIConfig name="DarkMode" enable="yes" colorTone="32" customColorTop="{{ self::bgr(c=l.base) }}" customColorMenuHotTrack="{{ self::bgr(c=l.surface1) }}" customColorActive="{{ self::bgr(c=l.mantle) }}" customColorMain="{{ self::bgr(c=l.crust) }}" customColorError="{{ self::bgr(c=l.red) }}" customColorText="{{ self::bgr(c=l.text) }}" customColorDarkText="{{ self::bgr(c=l.subtext1) }}" customColorDisabledText="{{ self::bgr(c=l.subtext0) }}" customColorLinkText="{{ self::bgr(c=l.blue)}}" customColorEdge="{{ self::bgr(c=l.overlay1) }}" customColorHotEdge="{{ self::bgr(c=l.overlay2) }}" customColorDisabledEdge="{{ self::bgr(c=l.overlay0) }}" enableWindowsMode="no" darkThemeName="catppuccin-{{ flavor.identifier }}.xml" darkToolBarIconSet="0" darkTbFluentColor="9" darkTbFluentCustomColor="{{ self::bgr(c=l.blue) }}" darkTbFluentMono="{{ if(cond=flavor.dark, t="no", f="yes") }}" darkTabIconSet="2" darkTabUseTheme="yes" lightThemeName="catppuccin-{{ flavor.identifier }}.xml" lightToolBarIconSet="0" lightTbFluentColor="9" lightTbFluentCustomColor="{{ self::bgr(c=flavors.latte.colors.blue) }}" lightTbFluentMono="no" lightTabIconSet="2" lightTabUseTheme="yes" />
 ```
 
 </details>

--- a/ui-theme.md
+++ b/ui-theme.md
@@ -3,17 +3,32 @@
 Notepad++ has limited support for customizing the UI elements.
 Some elements are controlled by the Windows theme (menu dropdowns, scrollbars, etc.) and can't be changed.
 
-You can theme the supported elements by modifying a line in the file `%AppData%/Notepad++/config.xml`.
-Replace the line beginning with `<GUIConfig name="DarkMode">` with the desired flavor.
+Some aspects of the color theme can optionally be enabled in the UI settings dialog:
+- Preferences > Editing 1
+  - Apply custom color to selected text foreground
+- Preferences > Editing 2
+  - EOL (CRLF) > Custom Color
+  - Non-Printing Characters > Appearance > Custom Color
+  - Non-Printing Characters > Apply Appearance to C0, C1, EOL
+- Preferences > Toolbar > Pick an icon theme
+  - Pick "Complete" or "Partial" Colorization
+  - Color choice > Custom
+- Preferences > Margins/Border/Edge > Pick what you like
 
-> [!NOTE]
+You can theme the UI elements by modifying a line in the config file (Default: `%AppData%/Notepad++/config.xml`)
+
+Replace the line beginning with `<GUIConfig name="DarkMode" ...>` with the desired flavor.
+
+Some options may not be available in older versions of Notepad++. If you recently updated, add this line to the config again, as older versions will delete unused properties.
+
+> [!WARNING]
 > You cannot use Notepad++ to make this change, as it will overwrite any changes to `config.xml` when closing.
 
 <details>
 <summary>🌻 Latte</summary>
 
 ```xml
-<GUIConfig name="DarkMode" enable="yes" colorTone="32" customColorTop="16118255" customColorMenuHotTrack="13418684" customColorActive="15722982" customColorMain="15261916" customColorError="3739602" customColorText="6901580" customColorDarkText="7823196" customColorDisabledText="8744812" customColorLinkText="16082462" customColorEdge="10588044" customColorHotEdge="9666428" customColorDisabledEdge="11575452" enableWindowsMode="no" darkThemeName="catppuccin-latte.xml" darkToolBarIconSet="2" darkTabIconSet="2" darkTabUseTheme="yes" lightThemeName="catppuccin-latte.xml" lightToolBarIconSet="4" lightTabIconSet="0" lightTabUseTheme="yes" />
+<GUIConfig name="DarkMode" enable="yes" colorTone="32" customColorTop="16118255" customColorMenuHotTrack="13418684" customColorActive="15722982" customColorMain="15261916" customColorError="3739602" customColorText="6901580" customColorDarkText="7823196" customColorDisabledText="8744812" customColorLinkText="16082462" customColorEdge="10588044" customColorHotEdge="9666428" customColorDisabledEdge="11575452" enableWindowsMode="no" darkThemeName="catppuccin-latte.xml" darkToolBarIconSet="0" darkTbFluentColor="9" darkTbFluentCustomColor="16082462" darkTbFluentMono="yes" darkTabIconSet="2" darkTabUseTheme="yes" lightThemeName="catppuccin-latte.xml" lightToolBarIconSet="0" lightTbFluentColor="9" lightTbFluentCustomColor="16082462" lightTbFluentMono="no" lightTabIconSet="2" lightTabUseTheme="yes" />
 ```
 
 </details>
@@ -21,7 +36,7 @@ Replace the line beginning with `<GUIConfig name="DarkMode">` with the desired f
 <summary>🪴 Frappé</summary>
 
 ```xml
-<GUIConfig name="DarkMode" enable="yes" colorTone="32" customColorTop="4600880" customColorMenuHotTrack="7165777" customColorActive="3943465" customColorMain="3417635" customColorError="8684263" customColorText="16109766" customColorDarkText="14860213" customColorDisabledText="13544869" customColorLinkText="15641228" customColorEdge="10980227" customColorHotEdge="12295316" customColorDisabledEdge="9730419" enableWindowsMode="no" darkThemeName="catppuccin-frappe.xml" darkToolBarIconSet="2" darkTabIconSet="2" darkTabUseTheme="yes" lightThemeName="catppuccin-frappe.xml" lightToolBarIconSet="4" lightTabIconSet="0" lightTabUseTheme="yes" />
+<GUIConfig name="DarkMode" enable="yes" colorTone="32" customColorTop="4600880" customColorMenuHotTrack="7165777" customColorActive="3943465" customColorMain="3417635" customColorError="8684263" customColorText="16109766" customColorDarkText="14860213" customColorDisabledText="13544869" customColorLinkText="15641228" customColorEdge="10980227" customColorHotEdge="12295316" customColorDisabledEdge="9730419" enableWindowsMode="no" darkThemeName="catppuccin-frappe.xml" darkToolBarIconSet="0" darkTbFluentColor="9" darkTbFluentCustomColor="15641228" darkTbFluentMono="no" darkTabIconSet="2" darkTabUseTheme="yes" lightThemeName="catppuccin-frappe.xml" lightToolBarIconSet="0" lightTbFluentColor="9" lightTbFluentCustomColor="16082462" lightTbFluentMono="no" lightTabIconSet="2" lightTabUseTheme="yes" />
 ```
 
 </details>
@@ -29,7 +44,7 @@ Replace the line beginning with `<GUIConfig name="DarkMode">` with the desired f
 <summary>🌺 Macchiato</summary>
 
 ```xml
-<GUIConfig name="DarkMode" enable="yes" colorTone="32" customColorTop="3811108" customColorMenuHotTrack="6573385" customColorActive="3153950" customColorMain="2496792" customColorError="9865197" customColorText="16110538" customColorDarkText="14729400" customColorDisabledText="13348261" customColorLinkText="16035210" customColorEdge="10651520" customColorHotEdge="12032659" customColorDisabledEdge="9270126" enableWindowsMode="no" darkThemeName="catppuccin-macchiato.xml" darkToolBarIconSet="2" darkTabIconSet="2" darkTabUseTheme="yes" lightThemeName="catppuccin-macchiato.xml" lightToolBarIconSet="4" lightTabIconSet="0" lightTabUseTheme="yes" />
+<GUIConfig name="DarkMode" enable="yes" colorTone="32" customColorTop="3811108" customColorMenuHotTrack="6573385" customColorActive="3153950" customColorMain="2496792" customColorError="9865197" customColorText="16110538" customColorDarkText="14729400" customColorDisabledText="13348261" customColorLinkText="16035210" customColorEdge="10651520" customColorHotEdge="12032659" customColorDisabledEdge="9270126" enableWindowsMode="no" darkThemeName="catppuccin-macchiato.xml" darkToolBarIconSet="0" darkTbFluentColor="9" darkTbFluentCustomColor="16035210" darkTbFluentMono="no" darkTabIconSet="2" darkTabUseTheme="yes" lightThemeName="catppuccin-macchiato.xml" lightToolBarIconSet="0" lightTbFluentColor="9" lightTbFluentCustomColor="16082462" lightTbFluentMono="no" lightTabIconSet="2" lightTabUseTheme="yes" />
 ```
 
 </details>
@@ -37,7 +52,7 @@ Replace the line beginning with `<GUIConfig name="DarkMode">` with the desired f
 <summary>🌿 Mocha</summary>
 
 ```xml
-<GUIConfig name="DarkMode" enable="yes" colorTone="32" customColorTop="3022366" customColorMenuHotTrack="5916485" customColorActive="2431000" customColorMain="1773841" customColorError="11045875" customColorText="16045773" customColorDarkText="14598842" customColorDisabledText="13151654" customColorLinkText="16430217" customColorEdge="10257535" customColorHotEdge="11704723" customColorDisabledEdge="8810604" enableWindowsMode="no" darkThemeName="catppuccin-mocha.xml" darkToolBarIconSet="2" darkTabIconSet="2" darkTabUseTheme="yes" lightThemeName="catppuccin-mocha.xml" lightToolBarIconSet="4" lightTabIconSet="0" lightTabUseTheme="yes" />
+<GUIConfig name="DarkMode" enable="yes" colorTone="32" customColorTop="3022366" customColorMenuHotTrack="5916485" customColorActive="2431000" customColorMain="1773841" customColorError="11045875" customColorText="16045773" customColorDarkText="14598842" customColorDisabledText="13151654" customColorLinkText="16430217" customColorEdge="10257535" customColorHotEdge="11704723" customColorDisabledEdge="8810604" enableWindowsMode="no" darkThemeName="catppuccin-mocha.xml" darkToolBarIconSet="0" darkTbFluentColor="9" darkTbFluentCustomColor="16430217" darkTbFluentMono="no" darkTabIconSet="2" darkTabUseTheme="yes" lightThemeName="catppuccin-mocha.xml" lightToolBarIconSet="0" lightTbFluentColor="9" lightTbFluentCustomColor="16082462" lightTbFluentMono="no" lightTabIconSet="2" lightTabUseTheme="yes" />
 ```
 
 </details>


### PR DESCRIPTION
Introduced in Notepad++ v8.8. Latte will use mono-color icons, for
contrast reasons. We are abusing Npp "Dark Mode" feature for a light
mode color scheme.

docs: more detailed UI settings description

Add information about new UI options that Users might optionally want to
enable.

docs: clarify behaviour on older versions

When testing, I didn't get any errors, but Notepad++ did overwrite the
config file (like it does everytime) with only the recognized options.
